### PR TITLE
Allow disabling and enabling of graffinity aggregation features

### DIFF
--- a/src/components/AdjMatrix/AdjMatrix.vue
+++ b/src/components/AdjMatrix/AdjMatrix.vue
@@ -15,6 +15,10 @@ export default Vue.extend({
       type: Boolean,
       default: true,
     },
+    enableGraffinity: {
+      type: Boolean,
+      required: true,
+    },
     visualizedAttributes: {
       type: Array,
       default: () => [],
@@ -44,10 +48,11 @@ export default Vue.extend({
 
   computed: {
     properties(this: any) {
-      const { network, visualizedAttributes } = this;
+      const { network, visualizedAttributes, enableGraffinity } = this;
       return {
         network,
         visualizedAttributes,
+        enableGraffinity,
       };
     },
 
@@ -120,6 +125,7 @@ export default Vue.extend({
       this.matrixNodeLength,
       this.cellSize,
       this.visMargins,
+      this.enableGraffinity,
     );
     this.$emit('updateMatrixLegendScale', this.view.colorScale);
   },
@@ -129,6 +135,8 @@ export default Vue.extend({
       if (this.view) {
         this.view.visualizedAttributes = this.visualizedAttributes as string[];
         this.view.updateAttributes();
+
+        this.view.enableGraffinity = this.enableGraffinity;
       }
     },
     changeMatrix(this: any) {
@@ -166,6 +174,7 @@ export default Vue.extend({
         this.matrixNodeLength,
         this.cellSize,
         this.visMargins,
+        this.enableGraffinity,
       );
     },
   },

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -144,7 +144,6 @@ export class View {
       .attr('x', (d: string, i: number) => (colWidth + this.colMargin) * i)
       .attr('width', colWidth)
       .on('click', (d: string) => {
-        console.log('clicked the text label');
         if (this.enableGraffinity) {
           this.network = superGraph(this.network.nodes, this.network.links, d);
           eventBus.$emit('updateNetwork', this.network);

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -20,6 +20,7 @@ declare const reorder: any;
 
 export class View {
   public visualizedAttributes: string[] = [];
+  public enableGraffinity: boolean;
 
   private network: Network;
   private icons: { [key: string]: { [d: string]: string } };
@@ -65,6 +66,7 @@ export class View {
     matrixNodeLength: number,
     cellSize: number,
     visMargins: { left: number; top: number; right: number; bottom: number },
+    enableGraffinity: boolean,
   ) {
     this.network = network;
     this.visMargins = visMargins;
@@ -78,6 +80,7 @@ export class View {
     this.visualizedAttributes = visualizedAttributes;
     this.matrixNodeLength = matrixNodeLength;
     this.cellSize = cellSize;
+    this.enableGraffinity = enableGraffinity;
 
     this.icons = {
       quant: {
@@ -139,7 +142,9 @@ export class View {
       .attr('width', colWidth)
       .on('click', (d: string) => {
         console.log('clicked the text label');
-        this.network = superGraph(this.network.nodes, this.network.links, d);
+        if (this.enableGraffinity) {
+          this.network = superGraph(this.network.nodes, this.network.links, d);
+        }
       });
 
     // Calculate the attribute scales

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -20,6 +20,7 @@ export default Vue.extend({
     networkName: string;
     selectNeighbors: boolean;
     showGridLines: boolean;
+    enableGraffinity: boolean;
     visualizedAttributes: string[];
     nodeEditor: boolean;
     // connectivity is left with type any since it is a temp object in our AQL example
@@ -34,6 +35,7 @@ export default Vue.extend({
       networkName: '',
       selectNeighbors: true,
       showGridLines: true,
+      enableGraffinity: false,
       visualizedAttributes: [],
       nodeEditor: false,
       connectivity: {
@@ -172,6 +174,23 @@ export default Vue.extend({
               <v-checkbox class="ma-0" v-model="showGridLines" hide-details />
             </v-card-subtitle>
 
+            <!-- Graffinity Toggle -->
+            <v-card-subtitle
+              class="pb-0 px-0"
+              style="
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+              "
+            >
+              Enable Graffinity Features
+              <v-checkbox
+                class="ma-0"
+                v-model="enableGraffinity"
+                hide-details
+              />
+            </v-card-subtitle>
+
             <!-- Matrix Legend -->
             <v-card-subtitle
               class="pb-0 px-0"
@@ -208,6 +227,7 @@ export default Vue.extend({
               network,
               selectNeighbors,
               showGridLines,
+              enableGraffinity,
               visualizedAttributes,
             }"
             @restart-simulation="hello()"


### PR DESCRIPTION
Depends on #120.

Adds a boolean flag to enable/disable the superGraph creation, and some UI to manage the toggling. Currently, this code just disables the attribute column header selection, since @mozartfish told me that the "Aggregate California" button will be removed before he merges #120. This should disable any call to `superGraph()`, thus disabling the graffinity features

Leaving as a draft for now, until @mozartfish merges #120.

Closes https://github.com/orgs/multinet-app/projects/6#card-48781425