### PR TITLE
Add eventBus to emit and catch network update from the class object to the vue component

### DIFF
--- a/src/components/AdjMatrix/AdjMatrix.vue
+++ b/src/components/AdjMatrix/AdjMatrix.vue
@@ -5,9 +5,6 @@ import Vue, { PropType } from 'vue';
 import { View } from '@/components/AdjMatrix/AdjMatrixMethods';
 import { Dimensions, Network } from '@/types';
 
-// This is to be removed (stop-gap solution to superGraph network update)
-export const eventBus = new Vue();
-
 export default Vue.extend({
   props: {
     network: {
@@ -93,10 +90,6 @@ export default Vue.extend({
   },
 
   async mounted(this: any) {
-    eventBus.$on('updateNetwork', (network: Network) => {
-      this.network = network;
-    });
-
     this.browser.width =
       window.innerWidth ||
       document.documentElement.clientWidth ||

--- a/src/components/AdjMatrix/AdjMatrix.vue
+++ b/src/components/AdjMatrix/AdjMatrix.vue
@@ -5,6 +5,9 @@ import Vue, { PropType } from 'vue';
 import { View } from '@/components/AdjMatrix/AdjMatrixMethods';
 import { Dimensions, Network } from '@/types';
 
+// This is to be removed (stop-gap solution to superGraph network update)
+export const eventBus = new Vue();
+
 export default Vue.extend({
   props: {
     network: {
@@ -90,6 +93,10 @@ export default Vue.extend({
   },
 
   async mounted(this: any) {
+    eventBus.$on('updateNetwork', (network: Network) => {
+      this.network = network;
+      });
+
     this.browser.width =
       window.innerWidth ||
       document.documentElement.clientWidth ||

--- a/src/components/AdjMatrix/AdjMatrix.vue
+++ b/src/components/AdjMatrix/AdjMatrix.vue
@@ -95,7 +95,7 @@ export default Vue.extend({
   async mounted(this: any) {
     eventBus.$on('updateNetwork', (network: Network) => {
       this.network = network;
-      });
+    });
 
     this.browser.width =
       window.innerWidth ||

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -16,6 +16,9 @@ import 'science';
 import 'reorder.js';
 import { Link, Network, Node, Cell, State } from '@/types';
 
+// This is to be removed (stop-gap solution to superGraph network update)
+import { eventBus } from '@/components/AdjMatrix/AdjMatrix.vue';
+
 declare const reorder: any;
 
 export class View {
@@ -140,6 +143,7 @@ export class View {
       .on('click', (d: string) => {
         console.log('clicked the text label');
         this.network = superGraph(this.network.nodes, this.network.links, d);
+        eventBus.$emit('updateNetwork', this.network);
       });
 
     // Calculate the attribute scales

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -17,7 +17,7 @@ import 'reorder.js';
 import { Link, Network, Node, Cell, State } from '@/types';
 
 // This is to be removed (stop-gap solution to superGraph network update)
-import { eventBus } from '@/components/AdjMatrix/AdjMatrix.vue';
+import { eventBus } from '@/components/Controls.vue';
 
 declare const reorder: any;
 

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -105,6 +105,7 @@ export default Vue.extend({
       legendSVG.select('.legendLinear').call(legendLinear);
     },
     aggregateCaliforniaNodes(this: any) {
+      //
     },
   },
   watch: {

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -9,6 +9,9 @@ import { getUrlVars } from '@/lib/utils';
 import { loadData } from '@/lib/multinet';
 import { Network } from '@/types';
 
+// This is to be removed (stop-gap solution to superGraph network update)
+export const eventBus = new Vue();
+
 export default Vue.extend({
   components: {
     AdjMatrix,
@@ -75,6 +78,11 @@ export default Vue.extend({
     this.network = await loadData(workspace, networkName, host);
     this.workspace = workspace;
     this.networkName = networkName;
+
+    // Catch network update events here to propagate new data into the app.
+    eventBus.$on('updateNetwork', (network: Network) => {
+      this.network = network;
+    });
   },
 
   methods: {


### PR DESCRIPTION
Adds a stop-gap solution to update the network object in the vue component from a change in the matrix ts class. This will need to be backed out when we do the re-architecting.

It might make sense to make an issue to track backing this logic out