### PR TITLE
Expand Aggregation Visualization

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "format:fix": "prettier --write '**/*.{js,ts,css,vue}'"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.32",
+    "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@types/d3": "^5.7.2",
     "core-js": "^3.4.3",
     "d3": "^5.14.2",

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -38,7 +38,7 @@ export default Vue.extend({
         height: 0,
         width: 0,
       },
-      visMargins: { left: 75, top: 75, right: 0, bottom: 0 },
+      visMargins: { left: 150, top: 75, right: 0, bottom: 0 },
       matrix: undefined,
       attributes: undefined,
       view: undefined,

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -601,9 +601,7 @@ export class View {
         const viewStatus = View.clickMap.get(superNode.id);
         if (viewStatus != undefined) {
           if (viewStatus === false) {
-            console.log('expand super visualization');
             View.clickMap.set(superNode.id, true);
-            console.log('call the expand super network function');
             expandSuperNetwork(
               View.nonAggrNetwork,
               View.aggrNetwork,
@@ -617,11 +615,15 @@ export class View {
           }
         } else {
           View.clickMap.set(superNode.id, true);
-          // console.log('expand super visualization');
-          // console.log('call the expand super network function');
-          View.aggrNetwork = expandSuperNetwork(View.nonAggrNetwork, View.aggrNetwork, superNode);
-          eventBus.$emit('updateNetwork', View.aggrNetwork);
-          // console.log(View.clickMap);
+          expandSuperNetwork(View.nonAggrNetwork, View.aggrNetwork, superNode);
+
+          const expandVisNetwork = expandSuperNetwork(
+            View.nonAggrNetwork,
+            View.aggrNetwork,
+            superNode,
+          );
+          eventBus.$emit('updateNetwork', expandVisNetwork);
+          console.log(View.clickMap);
         }
       } else {
         console.log('aggregation vis not activated');

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -619,7 +619,8 @@ export class View {
           View.clickMap.set(superNode.id, true);
           // console.log('expand super visualization');
           // console.log('call the expand super network function');
-          expandSuperNetwork(View.nonAggrNetwork, View.aggrNetwork, superNode);
+          View.aggrNetwork = expandSuperNetwork(View.nonAggrNetwork, View.aggrNetwork, superNode);
+          eventBus.$emit('updateNetwork', View.aggrNetwork);
           // console.log(View.clickMap);
         }
       } else {

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -10,7 +10,7 @@ import { schemeCategory10 } from 'd3-scale-chromatic';
 import { select, selectAll } from 'd3-selection';
 import { min, max, range } from 'd3-array';
 import { axisTop } from 'd3-axis';
-import { superGraph, MapNetworkNodes} from '@/lib/aggregation';
+import { superGraph, MapNetworkNodes, getSuperChildren} from '@/lib/aggregation';
 import * as ProvenanceLibrary from 'provenance-lib-core/lib/src/provenance-core/Provenance';
 import 'science';
 import 'reorder.js';
@@ -586,11 +586,17 @@ export class View {
       .classed('fa', true)
       .classed('fa-angle-right', true);
 
-    rowDropWidget.on('click', () => {
+    rowDropWidget.on('click', (d: Node) => {
       if (this.enableGraffinity) {
         if (this.visBool == 0) {
           console.log('expand supernodes');
+          console.log('super node name: ', d.id);
+          console.log('the node dictionary');
           console.log(View.nodeMap);
+          console.log('the supernodes');
+          console.log(this.visNetwork.nodes);
+          console.log("call the get super node children function");
+          getSuperChildren(d.id, this.visNetwork.nodes);
           this.visBool += 1;
         } else {
           console.log('retract supernodes');

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -542,8 +542,8 @@ export class View {
     const labelContainerHeight = 25;
     const rowLabelContainerStart = 75;
     const labelContainerWidth = rowLabelContainerStart;
-    const chevronWidth = 25;
-    const chevronHeight = 25;
+    const chevronWidth = 30;
+    const chevronHeight = 30;
 
     // add foreign objects for label
     const edgeRowForeignObject = this.edgeRows
@@ -569,15 +569,21 @@ export class View {
     // add row chevron widgets
     const rowDropWidget = this.edgeRows
       .append('foreignObject')
-      .attr('x', -(rowLabelContainerStart + 10))
+      .attr('x', -(rowLabelContainerStart + 40))
       .attr('y', -5)
       .attr('width', chevronWidth)
       .attr('height', chevronHeight);
 
     rowDropWidget
-      .append('svg')
+      .append('xhtml:div')
+      .append('i')
       .classed('fa', true)
       .classed('fa-angle-right', true);
+
+    rowDropWidget.on('click', (d: Node) => {
+      console.log(d._key);
+      console.log(d);
+    });
 
     let verticalOffset = 187.5;
     const horizontalOffset = (this.orderingScale.bandwidth() / 2 - 4.5) / 0.075;

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -10,7 +10,11 @@ import { schemeCategory10 } from 'd3-scale-chromatic';
 import { select, selectAll } from 'd3-selection';
 import { min, max, range } from 'd3-array';
 import { axisTop } from 'd3-axis';
-import { superGraph, MapNetworkNodes, getSuperChildren} from '@/lib/aggregation';
+import {
+  superGraph,
+  MapNetworkNodes,
+  ExpandSuperData
+} from '@/lib/aggregation';
 import * as ProvenanceLibrary from 'provenance-lib-core/lib/src/provenance-core/Provenance';
 import 'science';
 import 'reorder.js';
@@ -586,17 +590,11 @@ export class View {
       .classed('fa', true)
       .classed('fa-angle-right', true);
 
-    rowDropWidget.on('click', (d: Node) => {
+    rowDropWidget.on('click', (superNode: Node) => {
       if (this.enableGraffinity) {
         if (this.visBool == 0) {
           console.log('expand supernodes');
-          console.log('super node name: ', d.id);
-          console.log('the node dictionary');
-          console.log(View.nodeMap);
-          console.log('the supernodes');
-          console.log(this.visNetwork.nodes);
-          console.log("call the get super node children function");
-          getSuperChildren(d.id, this.visNetwork.nodes);
+          ExpandSuperData(superNode.id, this.visNetwork.nodes, View.nodeMap);
           this.visBool += 1;
         } else {
           console.log('retract supernodes');

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -31,7 +31,6 @@ dom.watch();
 export class View {
   public visualizedAttributes: string[] = [];
   public enableGraffinity: boolean;
-
   private network: Network;
   private visNetwork: Network;
   private icons: { [key: string]: { [d: string]: string } };
@@ -70,6 +69,7 @@ export class View {
   private maxNumConnections = -Infinity;
   private matrixNodeLength: number;
   private cellSize: number;
+  private visBool: number;
 
   constructor(
     network: Network,
@@ -93,6 +93,7 @@ export class View {
     this.matrixNodeLength = matrixNodeLength;
     this.cellSize = cellSize;
     this.enableGraffinity = enableGraffinity;
+    this.visBool = 0;
 
     this.icons = {
       quant: {
@@ -154,11 +155,11 @@ export class View {
       .attr('width', colWidth)
       .on('click', (d: string) => {
         if (this.enableGraffinity) {
-          this.visNetwork = superGraph(this.visNetwork.nodes, this.visNetwork.links, d);
-          console.log("vis network nodes");
-          console.log(this.visNetwork.nodes);
-          console.log("original network nodes");
-          console.log(this.network.nodes);
+          this.visNetwork = superGraph(
+            this.visNetwork.nodes,
+            this.visNetwork.links,
+            d,
+          );
           eventBus.$emit('updateNetwork', this.visNetwork);
         } else {
           this.sort(d);
@@ -586,9 +587,19 @@ export class View {
       .classed('fa', true)
       .classed('fa-angle-right', true);
 
-    rowDropWidget.on('click', (d: Node) => {
-      console.log(d._key);
-      console.log(d);
+    rowDropWidget.on('click', () => {
+      if (this.enableGraffinity) {
+        if (this.visBool == 0) {
+          console.log("expand supernodes");
+          this.visBool += 1;
+        }
+        else { 
+          console.log("retract supernodes");
+          this.visBool -= 1;
+        }
+      } else { 
+        console.log("aggregation vis not activated");
+      }
     });
 
     let verticalOffset = 187.5;
@@ -1090,7 +1101,8 @@ export class View {
       }
     } else if (this.sortKey === 'edges') {
       order = range(this.visNetwork.nodes.length).sort(
-        (a, b) => this.visNetwork.nodes[b][type] - this.visNetwork.nodes[a][type],
+        (a, b) =>
+          this.visNetwork.nodes[b][type] - this.visNetwork.nodes[a][type],
       );
     } else if (isNode === true) {
       order = range(this.visNetwork.nodes.length).sort((a, b) =>
@@ -1107,7 +1119,8 @@ export class View {
       );
     } else {
       order = range(this.visNetwork.nodes.length).sort(
-        (a, b) => this.visNetwork.nodes[b][type] - this.visNetwork.nodes[a][type],
+        (a, b) =>
+          this.visNetwork.nodes[b][type] - this.visNetwork.nodes[a][type],
       );
     }
     this.order = order;

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -10,11 +10,7 @@ import { schemeCategory10 } from 'd3-scale-chromatic';
 import { select, selectAll } from 'd3-selection';
 import { min, max, range } from 'd3-array';
 import { axisTop } from 'd3-axis';
-import {
-  superGraph,
-  MapNetworkNodes,
-  ExpandSuperData
-} from '@/lib/aggregation';
+import { superGraph, MapNetworkNodes } from '@/lib/aggregation';
 import * as ProvenanceLibrary from 'provenance-lib-core/lib/src/provenance-core/Provenance';
 import 'science';
 import 'reorder.js';
@@ -74,6 +70,8 @@ export class View {
   private cellSize: number;
   private visBool: number;
   static nodeMap: Map<string, Node>;
+  static nonAggrNetwork: Network; // variable for keeping track of the non-aggregated network
+  static aggrNetwork: Network; // variable for keeping track of the aggregated network
 
   constructor(
     network: Network,
@@ -158,12 +156,18 @@ export class View {
       .on('click', (d: string) => {
         if (this.enableGraffinity) {
           View.nodeMap = MapNetworkNodes(this.visNetwork.nodes);
-          this.visNetwork = superGraph(
-            this.visNetwork.nodes,
-            this.visNetwork.links,
-            d,
-          );
-          eventBus.$emit('updateNetwork', this.visNetwork);
+          View.nonAggrNetwork = this.visNetwork;
+          console.log("Non-Aggregated Network");
+          console.log(View.nonAggrNetwork);
+          View.aggrNetwork = superGraph(this.visNetwork.nodes, this.visNetwork.links, d);
+          console.log("Aggregated Network");
+          console.log(View.aggrNetwork);
+          // this.visNetwork = superGraph(
+          //   this.visNetwork.nodes,
+          //   this.visNetwork.links,
+          //   d,
+          // );
+          eventBus.$emit('updateNetwork', View.aggrNetwork);
         } else {
           this.sort(d);
         }
@@ -594,7 +598,7 @@ export class View {
       if (this.enableGraffinity) {
         if (this.visBool == 0) {
           console.log('expand supernodes');
-          ExpandSuperData(superNode.id, this.visNetwork.nodes, View.nodeMap);
+          console.log(superNode.id);
           this.visBool += 1;
         } else {
           console.log('retract supernodes');

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -15,11 +15,18 @@ import * as ProvenanceLibrary from 'provenance-lib-core/lib/src/provenance-core/
 import 'science';
 import 'reorder.js';
 import { Link, Network, Node, Cell, State } from '@/types';
+import { library, dom } from '@fortawesome/fontawesome-svg-core';
+import { faAngleRight } from '@fortawesome/free-solid-svg-icons';
 
 // This is to be removed (stop-gap solution to superGraph network update)
 import { eventBus } from '@/components/Controls.vue';
 
 declare const reorder: any;
+
+// these two lines of code are needed to add fontawesome icons
+// and have them render to the screen with vue
+library.add(faAngleRight);
+dom.watch();
 
 export class View {
   public visualizedAttributes: string[] = [];
@@ -535,6 +542,8 @@ export class View {
     const labelContainerHeight = 25;
     const rowLabelContainerStart = 75;
     const labelContainerWidth = rowLabelContainerStart;
+    const chevronWidth = 25;
+    const chevronHeight = 25;
 
     // add foreign objects for label
     const edgeRowForeignObject = this.edgeRows
@@ -556,6 +565,19 @@ export class View {
         this.selectElement(d);
         this.selectNeighborNodes(d.id, d.neighbors);
       });
+
+    // add row chevron widgets
+    const rowDropWidget = this.edgeRows
+      .append('foreignObject')
+      .attr('x', -(rowLabelContainerStart + 10))
+      .attr('y', -5)
+      .attr('width', chevronWidth)
+      .attr('height', chevronHeight);
+
+    rowDropWidget
+      .append('svg')
+      .classed('fa', true)
+      .classed('fa-angle-right', true);
 
     let verticalOffset = 187.5;
     const horizontalOffset = (this.orderingScale.bandwidth() / 2 - 4.5) / 0.075;

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -10,7 +10,7 @@ import { schemeCategory10 } from 'd3-scale-chromatic';
 import { select, selectAll } from 'd3-selection';
 import { min, max, range } from 'd3-array';
 import { axisTop } from 'd3-axis';
-import { superGraph } from '@/lib/aggregation';
+import { superGraph, MapNetworkNodes} from '@/lib/aggregation';
 import * as ProvenanceLibrary from 'provenance-lib-core/lib/src/provenance-core/Provenance';
 import 'science';
 import 'reorder.js';
@@ -31,7 +31,6 @@ dom.watch();
 export class View {
   public visualizedAttributes: string[] = [];
   public enableGraffinity: boolean;
-  private network: Network;
   private visNetwork: Network;
   private icons: { [key: string]: { [d: string]: string } };
   private sortKey: string;
@@ -70,6 +69,7 @@ export class View {
   private matrixNodeLength: number;
   private cellSize: number;
   private visBool: number;
+  static nodeMap: Map<string, Node>;
 
   constructor(
     network: Network,
@@ -79,7 +79,6 @@ export class View {
     visMargins: { left: number; top: number; right: number; bottom: number },
     enableGraffinity: boolean,
   ) {
-    this.network = network;
     this.visNetwork = network;
     this.visMargins = visMargins;
     this.provenance = this.setUpProvenance();
@@ -138,7 +137,6 @@ export class View {
       .data(this.visualizedAttributes);
 
     columnHeaderGroups.exit().remove();
-
     columnHeaderGroups
       .enter()
       .append('text')
@@ -155,6 +153,7 @@ export class View {
       .attr('width', colWidth)
       .on('click', (d: string) => {
         if (this.enableGraffinity) {
+          View.nodeMap = MapNetworkNodes(this.visNetwork.nodes);
           this.visNetwork = superGraph(
             this.visNetwork.nodes,
             this.visNetwork.links,
@@ -590,15 +589,15 @@ export class View {
     rowDropWidget.on('click', () => {
       if (this.enableGraffinity) {
         if (this.visBool == 0) {
-          console.log("expand supernodes");
+          console.log('expand supernodes');
+          console.log(View.nodeMap);
           this.visBool += 1;
-        }
-        else { 
-          console.log("retract supernodes");
+        } else {
+          console.log('retract supernodes');
           this.visBool -= 1;
         }
-      } else { 
-        console.log("aggregation vis not activated");
+      } else {
+        console.log('aggregation vis not activated');
       }
     });
 

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -2,8 +2,21 @@
 // and creates a new list of supernodes and a new list of edges
 // to reflect the connections between a supernode and the original nodes
 // in the network
-import { defineSuperNeighbors } from '@/lib/multinet';
 import { Link, Network, Node } from '@/types';
+
+// Function that constructs the neighbors for a node in a super network
+function defineNeighborNodes(nodes: Node[], links: Link[]) {
+  nodes.map((d: { neighbors: string[] }) => (d.neighbors = []));
+  links.forEach((link) => {
+    const findNodeFrom = nodes.find((node) => node.id === link._from);
+    const findNodeTo = nodes.find((node) => node.id === link._to);
+    if (findNodeFrom && findNodeTo != undefined) {
+      findNodeFrom.neighbors.push(link._to);
+      findNodeTo.neighbors.push(link._from);
+    }
+  });
+  return nodes;
+}
 export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
   // de-construct nodes into their original components and
   // make a new list of nodes
@@ -90,7 +103,8 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
   const combinedNodes = superNodes.concat(newNodes);
 
   // construct the neighbors for the nodes
-  const neighborNodes = defineSuperNeighbors(combinedNodes, newLinks);
+  // const neighborNodes = defineSuperNeighbors(combinedNodes, newLinks);
+  const neighborNodes = defineNeighborNodes(combinedNodes, newLinks);
 
   // remove all the nodes who do not have any neighbors
   let finalNodes = neighborNodes;
@@ -316,8 +330,23 @@ export function expandSuperNetwork(
     superNetwork.nodes,
   );
 
-  console.log('the expanded nodes');
-  console.log(expandNodes);
-  console.log('expand links');
-  console.log(expandLinks);
+  let neighborNodes: Node[] = [];
+  if (expandNodes && expandLinks != undefined) {
+    neighborNodes = defineNeighborNodes(expandNodes, expandLinks);
+    // console.log("neighbor nodes");
+    // console.log(neighborNodes);
+  }
+
+  // construct the new network
+  const network = {
+    nodes: neighborNodes,
+    links: expandLinks,
+  };
+  console.log('final network');
+  console.log(network);
+  return network;
+  // console.log('the expanded nodes');
+  // console.log(expandNodes);
+  // console.log('expand links');
+  // console.log(expandLinks);
 }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -191,8 +191,14 @@ function expandSuperDataNodes(
       superNodeCopy.splice(superIndexStart + count, 0, node);
       count += 1;
     });
-    console.log('network nodes after');
-    console.log(superNodeCopy);
+
+    // update the index of the new supernodes
+    superNodeCopy.forEach((node: Node, index: number) => {
+      node.index = index;
+    });
+    // console.log('network nodes after');
+    // console.log(superNodeCopy);
+    return superNodeCopy;
   }
 }
 
@@ -253,19 +259,16 @@ function expandSuperDataLinks(
     }
   });
 
-  console.log('the link subset after modification');
-  console.log(superChildrenLinks);
-
-  // merge the super network link copy with the superChildrenLinks
-  superChildrenLinks.concat(currentLinkCopy);
-  console.log("hello there");
-  console.log(superChildrenLinks);
-
-  // console.log("the current copy of links before modification");
-  // console.log(currentNetworkLinks);
-  // console.log("the current network links modified with the super children links");
+  // console.log('subset links');
+  // console.log(superChildrenLinks);
+  // console.log("copy links");
   // console.log(currentLinkCopy);
+  // console.log("attempt to concat");
+  const combinedLinks = currentLinkCopy.concat(superChildrenLinks);
+  return combinedLinks;
 
+  // console.log("the combined links");
+  // console.log(combinedLinks);
   // console.log('the original network links');
   // console.log(originalLinkCopy);
 
@@ -297,7 +300,7 @@ export function expandSuperNetwork(
   const superNetworkNodeMap = MapNetworkNodes(superNetwork.nodes);
 
   // calculate a new list of supernodes
-  expandSuperDataNodes(
+  const expandNodes = expandSuperDataNodes(
     superNodeName,
     superNetwork.nodes,
     originalNetworkNodeMap,
@@ -305,7 +308,7 @@ export function expandSuperNetwork(
   );
 
   // calculate a new set of links
-  expandSuperDataLinks(
+  const expandLinks = expandSuperDataLinks(
     superNodeName,
     superNetwork.links,
     originalNetwork.links,
@@ -313,5 +316,8 @@ export function expandSuperNetwork(
     superNetwork.nodes,
   );
 
-  // console.log(mapSuperChildren(superNetwork.nodes));
+  console.log('the expanded nodes');
+  console.log(expandNodes);
+  console.log('expand links');
+  console.log(expandLinks);
 }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -122,3 +122,16 @@ export function MapNetworkNodes(nodes: Node[]) {
 
   return nodeMap;
 }
+
+// function that takes a list of supernodes and returns their children
+export function getSuperChildren(superNodeName: string, nodes: Node[]) {
+  const superNodeMap = new Map<string, Node>();
+  console.log("the selected node: ", superNodeName);
+  nodes.forEach((node: Node) => {
+    superNodeMap.set(node.id, node);
+  });
+  const getSuperNode = superNodeMap.get(superNodeName);
+  if (getSuperNode) { 
+    console.log(getSuperNode.CHILDREN);
+  }
+}

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -123,15 +123,58 @@ export function MapNetworkNodes(nodes: Node[]) {
   return nodeMap;
 }
 
-// function that takes a list of supernodes and returns their children
-export function getSuperChildren(superNodeName: string, nodes: Node[]) {
+// function that takes a superNode name and list of supernodes
+// and returns the children of the supernode with a name that matches
+// the superNode name argument
+export function GetSuperChildren(superNodeName: string, nodes: Node[]) {
   const superNodeMap = new Map<string, Node>();
-  console.log("the selected node: ", superNodeName);
+  console.log('the selected node: ', superNodeName);
   nodes.forEach((node: Node) => {
     superNodeMap.set(node.id, node);
   });
   const getSuperNode = superNodeMap.get(superNodeName);
-  if (getSuperNode) { 
-    console.log(getSuperNode.CHILDREN);
+  if (getSuperNode) {
+    return getSuperNode.CHILDREN;
   }
+}
+
+// function that that takes a list of the current supernodes being visualized
+// a super node that was selected and modifies the data set to include the children
+// of supernodes to be visualized
+export function ExpandSuperData(
+  superNodeName: string,
+  superNodes: Node[],
+  nodeMap: Map<string, Node>,
+) {
+  // get the children of the supernode
+  const superChildrenIDs = GetSuperChildren(superNodeName, superNodes);
+  const childNodes: Node[] = [];
+
+  // loop through the node map and get the children nodes
+  superChildrenIDs.forEach((id: string) => {
+    const childNode = nodeMap.get(id);
+    if (childNode) {  
+      childNodes.push(childNode);
+    }
+  });
+
+  console.log("the children nodes");
+  console.log(childNodes);
+  // find the index of the supernode name
+  const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
+  const superIndexStart = superNodes.findIndex(superIndexFunc);
+  console.log(superNodes.findIndex(superIndexFunc));
+  console.log("the super node network before");
+  console.log(superNodes);
+  let count = 1;
+  childNodes.forEach(node => {
+    superNodes.splice(superIndexStart + count, 0, node);
+    count += 1;
+  });
+  console.log("the network after");
+  console.log(superNodes);
+
+
+
+
 }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -112,3 +112,13 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
 
   return network;
 }
+
+// function that maps node names to nodes
+export function MapNetworkNodes(nodes: Node[]) {
+  const nodeMap = new Map<string, Node>();
+  nodes.forEach((node: Node) => {
+    nodeMap.set(node.id, node);
+  });
+
+  return nodeMap;
+}

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -3,7 +3,7 @@
 // to reflect the connections between a supernode and the original nodes
 // in the network
 import { defineSuperNeighbors } from '@/lib/multinet';
-import { Link, Node } from '@/types';
+import { Link, Network, Node } from '@/types';
 export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
   // de-construct nodes into their original components and
   // make a new list of nodes
@@ -113,8 +113,9 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
   return network;
 }
 
-// function that maps node names to nodes
-export function MapNetworkNodes(nodes: Node[]) {
+// function that maps node names to node objects
+// <name, Node>
+function MapNetworkNodes(nodes: Node[]) {
   const nodeMap = new Map<string, Node>();
   nodes.forEach((node: Node) => {
     nodeMap.set(node.id, node);
@@ -123,58 +124,79 @@ export function MapNetworkNodes(nodes: Node[]) {
   return nodeMap;
 }
 
-// function that takes a superNode name and list of supernodes
-// and returns the children of the supernode with a name that matches
-// the superNode name argument
-export function GetSuperChildren(superNodeName: string, nodes: Node[]) {
-  const superNodeMap = new Map<string, Node>();
-  console.log('the selected node: ', superNodeName);
-  nodes.forEach((node: Node) => {
-    superNodeMap.set(node.id, node);
+// function that maps all supernode children to their parent supernode
+function mapSuperChildren(superNodes: Node[]) { 
+  // console.log(" the supernodes");
+  // console.log(superNodes);
+  const superChildrenMap = new Map<string, string>();
+  superNodes.forEach((parentNode: Node) => {
+    // console.log("parent node");
+    // console.log(parentNode);
+    const superChildren = parentNode.CHILDREN;
+    // console.log(superChildren);
+    superChildren.forEach((childNode: string) => {
+      superChildrenMap.set(childNode, parentNode.id);
+    });
+    // console.log(superChildrenMap);
   });
-  const getSuperNode = superNodeMap.get(superNodeName);
-  if (getSuperNode) {
-    return getSuperNode.CHILDREN;
-  }
+  // console.log("super children map");
+  // console.log(superChildrenMap);
+  return superChildrenMap;
 }
 
-// function that that takes a list of the current supernodes being visualized
-// a super node that was selected and modifies the data set to include the children
-// of supernodes to be visualized
-export function ExpandSuperData(
-  superNodeName: string,
-  superNodes: Node[],
-  nodeMap: Map<string, Node>,
-) {
-  // get the children of the supernode
-  const superChildrenIDs = GetSuperChildren(superNodeName, superNodes);
-  const childNodes: Node[] = [];
+// function that constructs a new network based on the supernode selected by the user
+export function expandSuperNetwork(originalNetwork: Network, superNetwork: Network, superNode: Node) { 
+  // console.log("the original network");
+  // console.log(originalNetwork);
+  // console.log("the super network");
+  // console.log(superNetwork);
+  console.log("The supernode selected");
+  console.log(superNode.id);
 
-  // loop through the node map and get the children nodes
-  superChildrenIDs.forEach((id: string) => {
-    const childNode = nodeMap.get(id);
-    if (childNode) {  
-      childNodes.push(childNode);
-    }
-  });
-
-  console.log("the children nodes");
-  console.log(childNodes);
-  // find the index of the supernode name
-  const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
-  const superIndexStart = superNodes.findIndex(superIndexFunc);
-  console.log(superNodes.findIndex(superIndexFunc));
-  console.log("the super node network before");
-  console.log(superNodes);
-  let count = 1;
-  childNodes.forEach(node => {
-    superNodes.splice(superIndexStart + count, 0, node);
-    count += 1;
-  });
-  console.log("the network after");
-  console.log(superNodes);
-
-
-
-
+  // map children names to nodes
+  const originalNetworkNodeMap = MapNetworkNodes(originalNetwork.nodes);
+  const superNetworkNodeMap = MapNetworkNodes(superNetwork.nodes);
+  console.log("original network map");
+  console.log(originalNetworkNodeMap);
+  console.log("supernetwork map");
+  console.log(superNetworkNodeMap);
+  console.log("super children map");
+  console.log(mapSuperChildren(superNetwork.nodes));
 }
+
+// // function that that takes a list of the current supernodes being visualized
+// // a super node that was selected and modifies the data set to include the children
+// // of supernodes to be visualized
+// export function ExpandSuperData(
+//   superNodeName: string,
+//   superNodes: Node[],
+//   nodeMap: Map<string, Node>,
+// ) {
+//   // get the children of the supernode
+//   const superChildrenIDs = GetSuperChildren(superNodeName, superNodes);
+//   const childNodes: Node[] = [];
+
+//   // loop through the node map and get the children nodes
+//   superChildrenIDs.forEach((id: string) => {
+//     const childNode = nodeMap.get(id);
+//     if (childNode) {
+//       childNodes.push(childNode);
+//     }
+//   });
+
+//   console.log('the children nodes');
+//   console.log(childNodes);
+//   // find the index of the supernode name
+//   const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
+//   const superIndexStart = superNodes.findIndex(superIndexFunc);
+//   console.log(superNodes.findIndex(superIndexFunc));
+//   console.log('the super node network before');
+//   console.log(superNodes);
+//   let count = 1;
+//   childNodes.forEach((node) => {
+//     superNodes.splice(superIndexStart + count, 0, node);
+//     count += 1;
+//   });
+//   console.log('the network after');
+//   console.log(superNodes);
+// }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -124,79 +124,96 @@ function MapNetworkNodes(nodes: Node[]) {
   return nodeMap;
 }
 
-// function that maps all supernode children to their parent supernode
-function mapSuperChildren(superNodes: Node[]) { 
-  // console.log(" the supernodes");
-  // console.log(superNodes);
-  const superChildrenMap = new Map<string, string>();
-  superNodes.forEach((parentNode: Node) => {
-    // console.log("parent node");
-    // console.log(parentNode);
-    const superChildren = parentNode.CHILDREN;
-    // console.log(superChildren);
-    superChildren.forEach((childNode: string) => {
-      superChildrenMap.set(childNode, parentNode.id);
+// // function that maps all supernode children to their parent supernode
+// function mapSuperChildren(superNodes: Node[]) {
+//   // console.log(" the supernodes");
+//   // console.log(superNodes);
+//   const superChildrenMap = new Map<string, string>();
+//   superNodes.forEach((parentNode: Node) => {
+//     // console.log("parent node");
+//     // console.log(parentNode);
+//     const superChildren = parentNode.CHILDREN;
+//     // console.log(superChildren);
+//     superChildren.forEach((childNode: string) => {
+//       superChildrenMap.set(childNode, parentNode.id);
+//     });
+//     // console.log(superChildrenMap);
+//   });
+//   // console.log("super children map");
+//   // console.log(superChildrenMap);
+//   return superChildrenMap;
+// }
+
+// function that takes a list of the current aggregated supernode network
+// and adds the children nodes for visualization
+function expandSuperData(
+  superNodeName: string,
+  currentNetworkNodes: Node[],
+  superChildrenIDMap: Map<string, Node>,
+  superNodeIDMap: Map<string, Node>,
+) {
+  // get the node information about the supernode name
+  const superNode = superNodeIDMap.get(superNodeName);
+  if (superNode != undefined) {
+    const superChildrenIDs = superNode.CHILDREN;
+    const childNodes: Node[] = [];
+    superChildrenIDs.forEach((id: string) => {
+      const childNode = superChildrenIDMap.get(id);
+      if (childNode != undefined) {
+        childNodes.push(childNode);
+      }
     });
-    // console.log(superChildrenMap);
-  });
-  // console.log("super children map");
-  // console.log(superChildrenMap);
-  return superChildrenMap;
+
+    console.log('the children nodes');
+    console.log(childNodes);
+
+    console.log('network nodes before');
+    console.log(currentNetworkNodes);
+    const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
+    const superIndexStart = currentNetworkNodes.findIndex(superIndexFunc);
+    console.log(currentNetworkNodes.findIndex(superIndexFunc));
+    console.log('the super node network before');
+    console.log(currentNetworkNodes);
+    let count = 1;
+    childNodes.forEach((node) => {
+      currentNetworkNodes.splice(superIndexStart + count, 0, node);
+      count += 1;
+    });
+    console.log('network nodes after');
+    console.log(currentNetworkNodes);
+  }
 }
 
+
 // function that constructs a new network based on the supernode selected by the user
-export function expandSuperNetwork(originalNetwork: Network, superNetwork: Network, superNode: Node) { 
+export function expandSuperNetwork(
+  originalNetwork: Network,
+  superNetwork: Network,
+  superNode: Node,
+) {
   // console.log("the original network");
   // console.log(originalNetwork);
   // console.log("the super network");
   // console.log(superNetwork);
-  console.log("The supernode selected");
-  console.log(superNode.id);
+  const superNodeName = superNode.id;
+  console.log('The supernode selected');
+  console.log(superNodeName);
+  // console.log('original network map');
+  // console.log(originalNetworkNodeMap);
+  // console.log('supernetwork map');
+  // console.log(superNetworkNodeMap);
+  // console.log('super children map');
 
   // map children names to nodes
   const originalNetworkNodeMap = MapNetworkNodes(originalNetwork.nodes);
   const superNetworkNodeMap = MapNetworkNodes(superNetwork.nodes);
-  console.log("original network map");
-  console.log(originalNetworkNodeMap);
-  console.log("supernetwork map");
-  console.log(superNetworkNodeMap);
-  console.log("super children map");
-  console.log(mapSuperChildren(superNetwork.nodes));
+  expandSuperData(
+    superNodeName,
+    superNetwork.nodes,
+    originalNetworkNodeMap,
+    superNetworkNodeMap,
+  );
+
+  // console.log(mapSuperChildren(superNetwork.nodes));
 }
 
-// // function that that takes a list of the current supernodes being visualized
-// // a super node that was selected and modifies the data set to include the children
-// // of supernodes to be visualized
-// export function ExpandSuperData(
-//   superNodeName: string,
-//   superNodes: Node[],
-//   nodeMap: Map<string, Node>,
-// ) {
-//   // get the children of the supernode
-//   const superChildrenIDs = GetSuperChildren(superNodeName, superNodes);
-//   const childNodes: Node[] = [];
-
-//   // loop through the node map and get the children nodes
-//   superChildrenIDs.forEach((id: string) => {
-//     const childNode = nodeMap.get(id);
-//     if (childNode) {
-//       childNodes.push(childNode);
-//     }
-//   });
-
-//   console.log('the children nodes');
-//   console.log(childNodes);
-//   // find the index of the supernode name
-//   const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
-//   const superIndexStart = superNodes.findIndex(superIndexFunc);
-//   console.log(superNodes.findIndex(superIndexFunc));
-//   console.log('the super node network before');
-//   console.log(superNodes);
-//   let count = 1;
-//   childNodes.forEach((node) => {
-//     superNodes.splice(superIndexStart + count, 0, node);
-//     count += 1;
-//   });
-//   console.log('the network after');
-//   console.log(superNodes);
-// }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -124,34 +124,44 @@ function MapNetworkNodes(nodes: Node[]) {
   return nodeMap;
 }
 
-// // function that maps all supernode children to their parent supernode
-// function mapSuperChildren(superNodes: Node[]) {
-//   // console.log(" the supernodes");
-//   // console.log(superNodes);
-//   const superChildrenMap = new Map<string, string>();
-//   superNodes.forEach((parentNode: Node) => {
-//     // console.log("parent node");
-//     // console.log(parentNode);
-//     const superChildren = parentNode.CHILDREN;
-//     // console.log(superChildren);
-//     superChildren.forEach((childNode: string) => {
-//       superChildrenMap.set(childNode, parentNode.id);
-//     });
-//     // console.log(superChildrenMap);
-//   });
-//   // console.log("super children map");
-//   // console.log(superChildrenMap);
-//   return superChildrenMap;
-// }
+// function that maps all supernode children to their parent supernode
+function mapSuperChildren(superNodes: Node[]) {
+  console.log(' the supernodes');
+  console.log(superNodes);
+  // const superChildrenMap = new Map<string, string>();
+  superNodes.forEach((parentNode: Node) => {
+    // console.log('parent node');
+    // console.log(parentNode);
+    const superChildren = parentNode.CHILDREN;
+    console.log(superChildren);
+    // superChildren.forEach((childNode: string) => {
+    //   superChildrenMap.set(childNode, parentNode.id);
+    // });
+    // console.log(superChildrenMap);
+  });
+  // // console.log("super children map");
+  // // console.log(superChildrenMap);
+  // return superChildrenMap;
+}
 
 // function that takes a list of the current aggregated supernode network
 // and adds the children nodes for visualization
-function expandSuperData(
+function expandSuperDataNodes(
   superNodeName: string,
   currentNetworkNodes: Node[],
   superChildrenIDMap: Map<string, Node>,
   superNodeIDMap: Map<string, Node>,
 ) {
+  // create a copy of the supernode data to handle the issue of modifying the supernodes
+  const superNodeCopy: Node[] = [];
+  currentNetworkNodes.map((node) => {
+    const newSuperNode = {
+      ...node,
+    };
+    newSuperNode.neighbors = [];
+    superNodeCopy.push(newSuperNode);
+  });
+
   // get the node information about the supernode name
   const superNode = superNodeIDMap.get(superNodeName);
   if (superNode != undefined) {
@@ -164,26 +174,73 @@ function expandSuperData(
       }
     });
 
-    console.log('the children nodes');
-    console.log(childNodes);
+    // console.log('the children nodes');
+    // console.log(childNodes);
 
-    console.log('network nodes before');
-    console.log(currentNetworkNodes);
+    // console.log('network nodes before');
+    // console.log(currentNetworkNodes);
     const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
-    const superIndexStart = currentNetworkNodes.findIndex(superIndexFunc);
-    console.log(currentNetworkNodes.findIndex(superIndexFunc));
-    console.log('the super node network before');
-    console.log(currentNetworkNodes);
+    const superIndexStart = superNodeCopy.findIndex(superIndexFunc);
+    // console.log(currentNetworkNodes.findIndex(superIndexFunc));
+    // console.log('the super node network before');
+    // console.log(currentNetworkNodes);
     let count = 1;
     childNodes.forEach((node) => {
-      currentNetworkNodes.splice(superIndexStart + count, 0, node);
+      superNodeCopy.splice(superIndexStart + count, 0, node);
       count += 1;
     });
     console.log('network nodes after');
-    console.log(currentNetworkNodes);
+    console.log(superNodeCopy);
   }
 }
 
+function expandSuperDataLinks(
+  superNodeName: string,
+  currentNetworkLinks: Link[],
+  originalNetworkLinks: Link[],
+  superChildrenIDMap: Map<string, Node>,
+  superNodeIDMap: Map<string, Node>,
+  superNodes: Node[],
+) {
+  // make copies of the links for modification without modifying the original data
+  const originalLinkCopy: Link[] = [];
+  const currentLinkCopy: Link[] = [];
+  originalNetworkLinks.forEach((link) => {
+    const newLink = {
+      ...link,
+    };
+    originalLinkCopy.push(newLink);
+  });
+  currentNetworkLinks.forEach(link => {
+    const newLink = {
+      ...link,
+    }
+    currentLinkCopy.push(newLink)
+  });
+
+  // get the node information about the supernode
+  const superNode = superNodeIDMap.get(superNodeName);
+  let superChildren: string[] = [];
+  if (superNode != undefined) {
+    superChildren = superNode.CHILDREN;
+  }
+  console.log('the children of the supernode selected');
+  console.log(superChildren);
+
+  // c
+  console.log('super parent children map');
+  mapSuperChildren(superNodes);
+  // console.log(superParentChildMap);
+
+  console.log('super children id map');
+  console.log(superChildrenIDMap);
+
+  console.log('the original network links');
+  console.log(originalLinkCopy);
+
+  console.log('the super network links');
+  console.log(currentLinkCopy);
+}
 
 // function that constructs a new network based on the supernode selected by the user
 export function expandSuperNetwork(
@@ -207,13 +264,24 @@ export function expandSuperNetwork(
   // map children names to nodes
   const originalNetworkNodeMap = MapNetworkNodes(originalNetwork.nodes);
   const superNetworkNodeMap = MapNetworkNodes(superNetwork.nodes);
-  expandSuperData(
+
+  // calculate a new list of supernodes
+  expandSuperDataNodes(
     superNodeName,
     superNetwork.nodes,
     originalNetworkNodeMap,
     superNetworkNodeMap,
   );
 
+  // calculate a new set of links
+  expandSuperDataLinks(
+    superNodeName,
+    superNetwork.links,
+    originalNetwork.links,
+    originalNetworkNodeMap,
+    superNetworkNodeMap,
+    superNetwork.nodes,
+  );
+
   // console.log(mapSuperChildren(superNetwork.nodes));
 }
-

--- a/src/lib/multinet.ts
+++ b/src/lib/multinet.ts
@@ -65,18 +65,6 @@ function _defineNeighbors(nodes: any[], links: any[]) {
   return nodes;
 }
 
-// Function that constructs the neighbors for a node in a super network
-export function defineSuperNeighbors(nodes: any[], links: any[]) {
-  nodes.map((d: { neighbors: string[] }) => (d.neighbors = []));
-  links.forEach((link) => {
-    const findNodeFrom = nodes.find((node) => node.id === link._from);
-    const findNodeTo = nodes.find((node) => node.id === link._to);
-    findNodeFrom.neighbors.push(link._to);
-    findNodeTo.neighbors.push(link._from);
-  });
-  return nodes;
-}
-
 export async function loadData(
   workspace: string,
   networkName: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -804,6 +804,25 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@fortawesome/fontawesome-common-types@^0.2.32":
+  version "0.2.32"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.32.tgz#3436795d5684f22742989bfa08f46f50f516f259"
+  integrity sha512-ux2EDjKMpcdHBVLi/eWZynnPxs0BtFVXJkgHIxXRl+9ZFaHPvYamAfCzeeQFqHRjuJtX90wVnMRaMQAAlctz3w==
+
+"@fortawesome/fontawesome-svg-core@^1.2.32":
+  version "1.2.32"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.32.tgz#da092bfc7266aa274be8604de610d7115f9ba6cf"
+  integrity sha512-XjqyeLCsR/c/usUpdWcOdVtWFVjPbDFBTQkn2fQRrWhhUoxriQohO2RWDxLyUM8XpD+Zzg5xwJ8gqTYGDLeGaQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.32"
+
+"@fortawesome/free-solid-svg-icons@^5.15.1":
+  version "5.15.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.1.tgz#e1432676ddd43108b41197fee9f86d910ad458ef"
+  integrity sha512-EFMuKtzRMNbvjab/SvJBaOOpaqJfdSap/Nl6hst7CgrJxwfORR1drdTV6q1Ib/JVzq4xObdTDcT6sqTaXMqfdg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.32"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"


### PR DESCRIPTION
This PR demonstrates expanding the aggregated visualization matrix when a user clicks on an aggregated category. Currently this PR works for expanding one category at a time. Further iterations will attempt to visualize multiple rows at once and retract rows when a user double clicks a specific chevron