### PR TITLE
Migrate initializeAttributes to MultiMatrix

### DIFF
--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -35,6 +35,7 @@ export default Vue.extend({
     idMap: { [key: string]: number };
     maxNumConnections: number;
     matrix: Cell[][];
+    edges: any;
   } {
     return {
       browser: {
@@ -49,6 +50,7 @@ export default Vue.extend({
       idMap: {},
       maxNumConnections: -Infinity,
       matrix: [],
+      edges: undefined,
     };
   },
 
@@ -139,6 +141,13 @@ export default Vue.extend({
     // Run process data to convert links to cells
     this.processData();
 
+    this.edges = select('#matrix')
+      .append('g')
+      .attr(
+        'transform',
+        `translate(${this.visMargins.left},${this.visMargins.top})`,
+      );
+
     // Define the View
     this.view = new View(
       this.network,
@@ -149,6 +158,7 @@ export default Vue.extend({
       this.matrix,
       this.maxNumConnections,
       this.orderingScale,
+      this.edges,
     );
     this.$emit('updateMatrixLegendScale', this.view.colorScale);
   },
@@ -190,6 +200,13 @@ export default Vue.extend({
           `0 0 ${this.attributesWidth} ${this.attributesHeight}`,
         );
 
+      this.edges = select('#matrix')
+        .append('g')
+        .attr(
+          'transform',
+          `translate(${this.visMargins.left},${this.visMargins.top})`,
+        );
+
       this.view = new View(
         this.network,
         this.visualizedAttributes,
@@ -199,6 +216,7 @@ export default Vue.extend({
         this.matrix,
         this.maxNumConnections,
         this.orderingScale,
+        this.edges,
       );
     },
 

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -277,7 +277,8 @@ export default Vue.extend({
     },
 
     initializeAttributes(): void {
-      const attributeWidth = 1000; // Just has to be larger than the attributes panel (so that we render to the edge)
+      // Just has to be larger than the attributes panel (so that we render to the edge)
+      const attributeWidth = 1000;
 
       this.attributes = select('#attributes')
         .append('g')

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -1,10 +1,9 @@
 <script lang="ts">
-import * as d3 from 'd3';
 import Vue, { PropType } from 'vue';
 
 import { View } from '@/components/MultiMatrix/MultiMatrixMethods';
 import { Cell, Dimensions, Link, Network, Node } from '@/types';
-import { range, ScaleBand, scaleBand } from 'd3';
+import { range, ScaleBand, scaleBand, select } from 'd3';
 
 export default Vue.extend({
   props: {
@@ -125,14 +124,12 @@ export default Vue.extend({
       document.body.clientHeight;
 
     // Size the svgs
-    this.matrixSVG = d3
-      .select(this.$refs.matrix)
+    this.matrixSVG = select(this.$refs.matrix)
       .attr('width', this.matrixWidth)
       .attr('height', this.matrixHeight)
       .attr('viewBox', `0 0 ${this.matrixWidth} ${this.matrixHeight}`);
 
-    this.attributes = d3
-      .select(this.$refs.attributes)
+    this.attributes = select(this.$refs.attributes)
       .attr('width', this.attributesWidth)
       .attr('height', this.attributesHeight)
       .attr('viewBox', `0 0 ${this.attributesWidth} ${this.attributesHeight}`);
@@ -167,7 +164,7 @@ export default Vue.extend({
     },
 
     changeMatrix(this: any) {
-      d3.select('#matrix').selectAll('*').remove();
+      select('#matrix').selectAll('*').remove();
 
       this.browser.width =
         window.innerWidth ||
@@ -180,14 +177,12 @@ export default Vue.extend({
         document.body.clientHeight;
 
       // Size the svgs
-      this.matrixSVG = d3
-        .select(this.$refs.matrix)
+      this.matrixSVG = select(this.$refs.matrix)
         .attr('width', this.matrixWidth)
         .attr('height', this.matrixHeight)
         .attr('viewBox', `0 0 ${this.matrixWidth} ${this.matrixHeight}`);
 
-      this.attributes = d3
-        .select(this.$refs.attributes)
+      this.attributes = select(this.$refs.attributes)
         .attr('width', this.attributesWidth)
         .attr('height', this.attributesHeight)
         .attr(

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -332,11 +332,11 @@ export default Vue.extend({
         .on('mouseout', (d: Node) => {
           this.hideToolTip();
           this.unHoverNode(d.id);
-        })
-        .on('click', (d: Node) => {
-          this.selectElement(d);
-          this.selectNeighborNodes(d.id, d.neighbors);
         });
+      // .on('click', (d: Node) => {
+      //   this.selectElement(d);
+      //   this.selectNeighborNodes(d.id, d.neighbors);
+      // });
 
       this.columnHeaders = this.attributes
         .append('g')

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -171,6 +171,7 @@ export default Vue.extend({
       this.attributes,
       this.attributeRows,
     );
+
     this.$emit('updateMatrixLegendScale', this.view.colorScale);
   },
 

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -4,6 +4,7 @@ import Vue, { PropType } from 'vue';
 
 import { View } from '@/components/MultiMatrix/MultiMatrixMethods';
 import { Cell, Dimensions, Link, Network, Node } from '@/types';
+import { range, ScaleBand, scaleBand } from 'd3';
 
 export default Vue.extend({
   props: {
@@ -89,6 +90,16 @@ export default Vue.extend({
     attributesHeight(): number {
       return this.matrixHeight;
     },
+
+    orderingScale(): ScaleBand<number> {
+      return scaleBand<number>()
+        .domain(range(0, this.matrix.length, 1))
+        .range([0, this.matrixHighlightLength]);
+    },
+
+    matrixHighlightLength(): number {
+      return this.matrix.length * this.cellSize;
+    },
   },
 
   watch: {
@@ -140,6 +151,7 @@ export default Vue.extend({
       this.enableGraffinity,
       this.matrix,
       this.maxNumConnections,
+      this.orderingScale,
     );
     this.$emit('updateMatrixLegendScale', this.view.colorScale);
   },
@@ -191,6 +203,7 @@ export default Vue.extend({
         this.enableGraffinity,
         this.matrix,
         this.maxNumConnections,
+        this.orderingScale,
       );
     },
 

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -336,8 +336,8 @@ svg >>> .hovered {
 
 svg >>> .clicked {
   font-weight: 800;
-  fill: #f8cf91 !important;
-  fill-opacity: 1 !important;
+  fill: #f8cf91;
+  fill-opacity: 1;
 }
 
 svg >>> .cell.clicked {

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -29,7 +29,7 @@ export default Vue.extend({
     browser: Dimensions;
     visMargins: any;
     matrixSVG: any;
-    attributes: any;
+    attributesSVG: any;
     view: View | undefined;
     cellSize: number;
     idMap: { [key: string]: number };
@@ -43,7 +43,7 @@ export default Vue.extend({
       },
       visMargins: { left: 75, top: 75, right: 0, bottom: 0 },
       matrixSVG: undefined,
-      attributes: undefined,
+      attributesSVG: undefined,
       view: undefined,
       cellSize: 15,
       idMap: {},
@@ -129,7 +129,7 @@ export default Vue.extend({
       .attr('height', this.matrixHeight)
       .attr('viewBox', `0 0 ${this.matrixWidth} ${this.matrixHeight}`);
 
-    this.attributes = select(this.$refs.attributes)
+    this.attributesSVG = select(this.$refs.attributes)
       .attr('width', this.attributesWidth)
       .attr('height', this.attributesHeight)
       .attr('viewBox', `0 0 ${this.attributesWidth} ${this.attributesHeight}`);
@@ -182,7 +182,7 @@ export default Vue.extend({
         .attr('height', this.matrixHeight)
         .attr('viewBox', `0 0 ${this.matrixWidth} ${this.matrixHeight}`);
 
-      this.attributes = select(this.$refs.attributes)
+      this.attributesSVG = select(this.$refs.attributes)
         .attr('width', this.attributesWidth)
         .attr('height', this.attributesHeight)
         .attr(

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -35,6 +35,9 @@ export default Vue.extend({
     idMap: { [key: string]: number };
     maxNumConnections: number;
     matrix: Cell[][];
+    attributes: any;
+    attributeRows: any;
+    columnHeaders: any;
     edges: any;
   } {
     return {
@@ -50,6 +53,9 @@ export default Vue.extend({
       idMap: {},
       maxNumConnections: -Infinity,
       matrix: [],
+      attributes: undefined,
+      attributeRows: undefined,
+      columnHeaders: undefined,
       edges: undefined,
     };
   },
@@ -158,7 +164,10 @@ export default Vue.extend({
       this.matrix,
       this.maxNumConnections,
       this.orderingScale,
+      this.columnHeaders,
       this.edges,
+      this.attributes,
+      this.attributeRows,
     );
     this.$emit('updateMatrixLegendScale', this.view.colorScale);
   },
@@ -216,7 +225,10 @@ export default Vue.extend({
         this.matrix,
         this.maxNumConnections,
         this.orderingScale,
+        this.columnHeaders,
         this.edges,
+        this.attributes,
+        this.attributeRows,
       );
     },
 

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -367,7 +367,7 @@ export class View {
         this.hideToolTip();
         this.unHoverEdge(d);
       })
-      .on('click', this.selectElement)
+      .on('click', (d:Cell) => this.selectElement(d))
       .attr('cursor', 'pointer');
 
     this.appendEdgeLabels();

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -107,7 +107,6 @@ export class View {
 
     // Kick off the rendering
     this.initializeEdges();
-    this.initializeAttributes();
   }
 
   public updateAttributes(): void {
@@ -866,37 +865,6 @@ export class View {
       .style('fill', '#8B8B8B')
       .filter((d: any) => d.id === order)
       .style('fill', '#EBB769');
-  }
-
-  /**
-   * [initializeAttributes description]
-   * @return [description]
-   */
-  private initializeAttributes(): void {
-    // let width = this.controller.visWidth * this.controller.attributeProportion;
-    // this.edgeWidth + this.margins.left + this.margins.right;
-    // let height = this.controller.visHeight;//this.edgeHeight + this.margins.top + this.margins.bottom;
-    // this.attributeWidth = width - (this.margins.left + this.margins.right) //* this.controller.attributeProportion;
-    // this.attributeHeight = height - (this.margins.top + this.margins.bottom)// * this.controller.attributeProportion;
-
-    const attributeWidth = 1000; // Just has to be larger than the attributes panel (so that we render to the edge)
-
-    this.attributes = select('#attributes')
-      .append('g')
-      .attr('transform', `translate(0,${this.visMargins.top})`);
-
-    // add zebras and highlight rows
-    this.attributes
-      .selectAll('.highlightRow')
-      .data(this.network.nodes)
-      .enter()
-      .append('rect')
-      .classed('highlightRow', true)
-      .attr('x', 0)
-      .attr('y', (d: Node, i: number) => this.orderingScale(i))
-      .attr('width', attributeWidth)
-      .attr('height', this.orderingScale.bandwidth())
-      .attr('fill', (d: Node, i: number) => (i % 2 === 0 ? '#fff' : '#eee'));
   }
 
   private isSelected(node: Node): boolean {

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -86,7 +86,10 @@ export class View {
     matrix: Cell[][],
     maxNumConnections: number,
     orderingScale: ScaleBand<number>,
+    columnHeaders: any,
     edges: any,
+    attributes: any,
+    attributeRows: any,
   ) {
     this.network = network;
     this.visMargins = visMargins;
@@ -97,7 +100,10 @@ export class View {
     this.matrix = matrix;
     this.maxNumConnections = maxNumConnections;
     this.orderingScale = orderingScale;
+    this.columnHeaders = columnHeaders;
     this.edges = edges;
+    this.attributes = attributes;
+    this.attributeRows = attributeRows;
 
     // Kick off the rendering
     this.initializeEdges();

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -377,6 +377,46 @@ export class View {
 
     this.appendEdgeLabels();
 
+    // Draw buttons for alternative sorts
+    let initialY = -this.visMargins.left + 10;
+    const buttonHeight = 15;
+    const text = ['name', 'cluster', 'interacts'];
+    const sortNames = ['shortName', 'clusterLeaf', 'edges'];
+    const iconNames = ['alphabetical', 'categorical', 'quant'];
+    for (let i = 0; i < 3; i++) {
+      const button = this.edges
+        .append('g')
+        .attr('transform', `translate(${-this.visMargins.left},${initialY})`);
+      button.attr('cursor', 'pointer');
+      button
+        .append('rect')
+        .attr('width', this.visMargins.left - 5)
+        .attr('height', buttonHeight)
+        .attr('fill', 'none')
+        .attr('stroke', 'gray')
+        .attr('stroke-width', 1);
+      button
+        .append('text')
+        .attr('x', 27)
+        .attr('y', 10)
+        .attr('font-size', 11)
+        .text(text[i]);
+      const path = button.datum(sortNames[i]);
+      path
+        .append('path')
+        .attr('class', 'sortIcon')
+        .attr('d', (d: any, i: number) => {
+          return this.icons[iconNames[i]].d;
+        })
+        .style('fill', () =>
+          sortNames[i] === this.orderType ? '#EBB769' : '#8B8B8B',
+        )
+        .attr('transform', 'scale(0.1)translate(-195,-320)')
+        .attr('cursor', 'pointer');
+      button.on('click', () => this.sort(sortNames[i]));
+      initialY += buttonHeight + 5;
+    }
+
     // Get tooltip
     this.tooltip = select('#tooltip');
   }
@@ -856,92 +896,6 @@ export class View {
       .attr('width', attributeWidth)
       .attr('height', this.orderingScale.bandwidth())
       .attr('fill', (d: Node, i: number) => (i % 2 === 0 ? '#fff' : '#eee'));
-
-    // Draw each row (translating the y coordinate)
-    this.attributeRows = this.attributes
-      .selectAll('.attrRowContainer')
-      .data(this.network.nodes)
-      .enter()
-      .append('g')
-      .attr('class', 'attrRowContainer')
-      .attr(
-        'transform',
-        (d: Node, i: number) => `translate(0,${this.orderingScale(i)})`,
-      );
-
-    this.attributeRows
-      .append('line')
-      .attr('x1', 0)
-      .attr('x2', attributeWidth)
-      .attr('stroke', '2px')
-      .attr('stroke-opacity', 0.3);
-
-    this.attributeRows
-      .append('rect')
-      .attr('x', 0)
-      .attr('y', 0)
-      .classed('attrRow', true)
-      .attr('id', (d: Node) => `attrRow${d.id}`)
-      .attr('width', attributeWidth)
-      .attr('height', this.orderingScale.bandwidth()) // end addition
-      .attr('fill-opacity', 0)
-      .attr('cursor', 'pointer')
-      .on('mouseover', (d: Node, i: number, nodes: any) => {
-        this.showToolTip(d, i, nodes);
-        this.hoverNode(d.id);
-      })
-      .on('mouseout', (d: Node) => {
-        this.hideToolTip();
-        this.unHoverNode(d.id);
-      })
-      .on('click', (d: Node) => {
-        this.selectElement(d);
-        this.selectNeighborNodes(d.id, d.neighbors);
-      });
-
-    this.columnHeaders = this.attributes
-      .append('g')
-      .classed('column-headers', true);
-
-    // Draw buttons for alternative sorts
-    let initialY = -this.visMargins.left + 10;
-    const buttonHeight = 15;
-    const text = ['name', 'cluster', 'interacts'];
-    const sortNames = ['shortName', 'clusterLeaf', 'edges'];
-    const iconNames = ['alphabetical', 'categorical', 'quant'];
-    for (let i = 0; i < 3; i++) {
-      const button = this.edges
-        .append('g')
-        .attr('transform', `translate(${-this.visMargins.left},${initialY})`);
-      button.attr('cursor', 'pointer');
-      button
-        .append('rect')
-        .attr('width', this.visMargins.left - 5)
-        .attr('height', buttonHeight)
-        .attr('fill', 'none')
-        .attr('stroke', 'gray')
-        .attr('stroke-width', 1);
-      button
-        .append('text')
-        .attr('x', 27)
-        .attr('y', 10)
-        .attr('font-size', 11)
-        .text(text[i]);
-      const path = button.datum(sortNames[i]);
-      path
-        .append('path')
-        .attr('class', 'sortIcon')
-        .attr('d', (d: any, i: number) => {
-          return this.icons[iconNames[i]].d;
-        })
-        .style('fill', () =>
-          sortNames[i] === this.orderType ? '#EBB769' : '#8B8B8B',
-        )
-        .attr('transform', 'scale(0.1)translate(-195,-320)')
-        .attr('cursor', 'pointer');
-      button.on('click', () => this.sort(sortNames[i]));
-      initialY += buttonHeight + 5;
-    }
   }
 
   private isSelected(node: Node): boolean {

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -1,10 +1,5 @@
 /* The View displays the data given to it by the model. */
-import {
-  ScaleLinear,
-  scaleLinear,
-  scaleOrdinal,
-  ScaleBand,
-} from 'd3-scale';
+import { ScaleLinear, scaleLinear, scaleOrdinal, ScaleBand } from 'd3-scale';
 import { schemeCategory10 } from 'd3-scale-chromatic';
 import { select, selectAll } from 'd3-selection';
 import { min, max, range } from 'd3-array';
@@ -285,7 +280,6 @@ export class View {
     // set the matrix highlight
     const matrixHighlightLength = this.matrix.length * this.cellSize;
 
-
     // creates column groupings
     this.edgeColumns = this.edges
       .selectAll('.column')
@@ -372,7 +366,7 @@ export class View {
         this.hideToolTip();
         this.unHoverEdge(d);
       })
-      .on('click', (d:Cell) => this.selectElement(d))
+      .on('click', (d: Cell) => this.selectElement(d))
       .attr('cursor', 'pointer');
 
     this.appendEdgeLabels();

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -86,6 +86,7 @@ export class View {
     matrix: Cell[][],
     maxNumConnections: number,
     orderingScale: ScaleBand<number>,
+    edges: any,
   ) {
     this.network = network;
     this.visMargins = visMargins;
@@ -96,6 +97,7 @@ export class View {
     this.matrix = matrix;
     this.maxNumConnections = maxNumConnections;
     this.orderingScale = orderingScale;
+    this.edges = edges;
 
     // Kick off the rendering
     this.initializeEdges();
@@ -278,13 +280,6 @@ export class View {
     // set the matrix highlight
     const matrixHighlightLength = this.matrix.length * this.cellSize;
 
-    // Creates scalable SVG
-    this.edges = select('#matrix')
-      .append('g')
-      .attr(
-        'transform',
-        `translate(${this.visMargins.left},${this.visMargins.top})`,
-      );
 
     // creates column groupings
     this.edgeColumns = this.edges

--- a/src/components/MultiMatrix/MultiMatrixMethods.ts
+++ b/src/components/MultiMatrix/MultiMatrixMethods.ts
@@ -1,6 +1,5 @@
 /* The View displays the data given to it by the model. */
 import {
-  scaleBand,
   ScaleLinear,
   scaleLinear,
   scaleOrdinal,
@@ -57,7 +56,7 @@ export class View {
     bottom: number;
   };
   private attributes: any;
-  private orderingScale: ScaleBand<number> = scaleBand<number>();
+  private orderingScale: ScaleBand<number>;
   public colorScale: ScaleLinear<string, number> = scaleLinear<
     string,
     number
@@ -86,6 +85,7 @@ export class View {
     enableGraffinity: boolean,
     matrix: Cell[][],
     maxNumConnections: number,
+    orderingScale: ScaleBand<number>,
   ) {
     this.network = network;
     this.visMargins = visMargins;
@@ -95,6 +95,7 @@ export class View {
     this.enableGraffinity = enableGraffinity;
     this.matrix = matrix;
     this.maxNumConnections = maxNumConnections;
+    this.orderingScale = orderingScale;
 
     // Kick off the rendering
     this.initializeEdges();
@@ -284,11 +285,6 @@ export class View {
         'transform',
         `translate(${this.visMargins.left},${this.visMargins.top})`,
       );
-
-    // sets the vertical scale
-    this.orderingScale = scaleBand<number>()
-      .domain(range(0, this.matrix.length, 1))
-      .range([0, matrixHighlightLength]);
 
     // creates column groupings
     this.edgeColumns = this.edges


### PR DESCRIPTION
Another step towards #141 

This moves the initialize attributes function to MultiMatrix.vue.

I had to duplicate some logic: `showTooltip`, `hideTooltip`, `isCell`, `capitalizeFirstLetter`, `hoverNode`, `unHoverNode`. The best strategy (that I could think of) was to duplicate the logic, since the code is used in both `initializeAtrributes` and `initializeEdges`. I'll remove the duplicated code when the `initializeEdges` is moved.

I also commented out the code for on click for the attribute rows to reduce the amount of duplicated code. I'll also re-enable that once I move `initializeEdges`.

This introduces a new bug that I'll have to track down. Sorting a aggregated network causes there to be a bunch of blank rows. I would guess that it's to do with how the network is being updated. I'll open an issue to track this before I merge and address this in my follow up PRs.

It might be time to target this to a longer running branch that tracks the rest of these removals (so we don't lose sight of fixing the bugs before we merge)

TODO:
- [x] Sorting aggregated network causes there to be some blank rows (open issue @JackWilb)