### PR TITLE
Expand Supernodes for matrix visualization

### DIFF
--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -69,6 +69,7 @@ export default Vue.extend({
     sortKey: string;
     colMargin: number;
     attributeScales: { [key: string]: any };
+    clickMap: any; // variable for keeping track of whether a label has been clicked or not
   } {
     return {
       browser: {
@@ -89,6 +90,7 @@ export default Vue.extend({
       edgeColumns: undefined,
       edgeRows: undefined,
       colorScale: scaleLinear<string, number>(),
+      clickMap: undefined,
       icons: {
         quant: {
           d:
@@ -579,8 +581,34 @@ export default Vue.extend({
           this.unHoverNode(d.id);
         })
         .on('click', (d: Node) => {
-          this.selectElement(d);
-          this.selectNeighborNodes(d.id, d.neighbors);
+          if (this.enableGraffinity) {
+            // create a new dictionary that checks whether a node has been clicked for
+            // expanding or retracting the matrix vis
+
+            if (this.clickMap.has(d.id)) {
+              // console.log("selection is in the map");
+              if (this.clickMap.get(d.id) === true) {
+                console.log('retract visualization');
+                this.clickMap.set(d.id, false);
+                console.log('click map state: ', this.clickMap);
+              } else {
+                console.log('expand visualization');
+                this.clickMap.set(d.id, true);
+                console.log('click map state: ', this.clickMap);
+              }
+            }
+            // if the selected node is not in the map
+            // add it to the map and visualize the expansion
+            else {
+              // console.log("new selection");
+              this.clickMap.set(d.id, true);
+              console.log('expand the visualization');
+              console.log('click map state: ', this.clickMap);
+            }
+          } else {
+            this.selectElement(d);
+            this.selectNeighborNodes(d.id, d.neighbors);
+          }
         });
 
       let verticalOffset = 187.5;
@@ -835,6 +863,7 @@ export default Vue.extend({
               'updateNetwork',
               superGraph(this.network.nodes, this.network.links, d),
             );
+            this.clickMap = new Map<string, boolean>();
           } else {
             this.sort(d);
           }

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -69,6 +69,8 @@ export default Vue.extend({
     sortKey: string;
     colMargin: number;
     attributeScales: { [key: string]: any };
+    nonAggrNodes: any;
+    nonAggrLinks: any;
     clickMap: any; // variable for keeping track of whether a label has been clicked or not
   } {
     return {
@@ -91,6 +93,8 @@ export default Vue.extend({
       edgeRows: undefined,
       colorScale: scaleLinear<string, number>(),
       clickMap: undefined,
+      nonAggrNodes: undefined,
+      nonAggrLinks: undefined,
       icons: {
         quant: {
           d:
@@ -580,10 +584,12 @@ export default Vue.extend({
           this.hideToolTip();
           this.unHoverNode(d.id);
         })
-        .on('click', (d: Node) => {
+        .on('click', (d: Node, i: number) => {
           if (this.enableGraffinity) {
             // create a new dictionary that checks whether a node has been clicked for
             // expanding or retracting the matrix vis
+            console.log('id and number selected: ', d.id, i);
+            console.log('node value: ', d);
 
             if (this.clickMap.has(d.id)) {
               // console.log("selection is in the map");
@@ -859,6 +865,10 @@ export default Vue.extend({
         .attr('width', colWidth)
         .on('click', (d: string) => {
           if (this.enableGraffinity) {
+            this.nonAggrNodes = this.processChildNodes(this.network.nodes);
+            this.nonAggrLinks = this.processChildLinks(this.network.links);
+            console.log('nodes before aggregation', this.nonAggrNodes);
+            console.log('links before aggregation', this.nonAggrLinks);
             this.$emit(
               'updateNetwork',
               superGraph(this.network.nodes, this.network.links, d),
@@ -1252,6 +1262,35 @@ export default Vue.extend({
 
     isCell(element: any): element is Cell {
       return Object.prototype.hasOwnProperty.call(element, 'cellName');
+    },
+
+    // function for processing nodes
+    processChildNodes(nodes: Node[]) {
+      const nodeCopy: Node[] = [];
+      // original network components
+      nodes.map((node: Node) => {
+        const newNode = {
+          ...node,
+        };
+        newNode.type = 'node';
+        nodeCopy.push(newNode);
+      });
+
+      return nodeCopy;
+    },
+
+    // function for processing links
+    processChildLinks(links: Link[]) {
+      const linkCopy: Link[] = [];
+      // original network components
+      links.map((link: Link) => {
+        const newLink = {
+          ...link,
+        };
+        newLink.type = 'link';
+        linkCopy.push(newLink);
+      });
+      return linkCopy;
     },
 
     capitalizeFirstLetter(word: string) {


### PR DESCRIPTION
This PR introduces a new feature that allows users to expand/retract the supernodes of an aggregated matrix visualization and view the connections between children nodes and supernodes