### PR TITLE
Restructured expand supernodes

### DIFF
--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -49,7 +49,7 @@ export default Vue.extend({
   },
 
   data(): {
-    superNetwork: Network;
+    // superNetwork: Network;
     browser: Dimensions;
     visMargins: any;
     matrixSVG: any;
@@ -79,10 +79,10 @@ export default Vue.extend({
     clickMap: any; // variable for keeping track of whether a label has been clicked or not
   } {
     return {
-      superNetwork: {
-        nodes: [],
-        links: [],
-      },
+      // superNetwork: {
+      //   nodes: [],
+      //   links: [],
+      // },
 
       browser: {
         height: 0,
@@ -192,9 +192,9 @@ export default Vue.extend({
       this.processData();
       this.changeMatrix();
     },
-    superNetwork() {
-      console.log('do something with the network');
-    },
+    // superNetwork() {
+    //   console.log('do something with the network');
+    // },
   },
 
   async mounted(this: any) {
@@ -602,6 +602,9 @@ export default Vue.extend({
             // create a new dictionary that checks whether a node has been clicked for
             // expanding or retracting the matrix vis
             console.log('id and number selected: ', d.id, i);
+            if (d.type === 'node') {
+              return;
+            }
             const superNode = d;
             // console.log('node value: ', d);
 
@@ -612,20 +615,23 @@ export default Vue.extend({
                 retractSuperNetwork(
                   this.nonAggrNodes,
                   this.nonAggrLinks,
-                  this.superNetwork.nodes,
-                  this.superNetwork.links,
+                  this.network.nodes,
+                  this.network.links,
                   superNode,
                 );
                 this.clickMap.set(d.id, false);
                 console.log('click map state: ', this.clickMap);
               } else {
                 console.log('expand visualization');
-                this.superNetwork = expandSuperNetwork(
-                  this.nonAggrNodes,
-                  this.nonAggrLinks,
-                  this.superNetwork.nodes,
-                  this.superNetwork.links,
-                  superNode,
+                this.$emit(
+                  'updateNetwork',
+                  expandSuperNetwork(
+                    this.nonAggrNodes,
+                    this.nonAggrLinks,
+                    this.network.nodes,
+                    this.network.links,
+                    superNode,
+                  ),
                 );
                 this.clickMap.set(d.id, true);
                 console.log('click map state: ', this.clickMap);
@@ -635,18 +641,21 @@ export default Vue.extend({
             else if (this.clickMap.size != 0) {
               console.log('the click map has at least one node expanded');
               console.log('expand visualization');
-              this.superNetwork = expandSuperNetwork(
-                this.nonAggrNodes,
-                this.nonAggrLinks,
-                this.superNetwork.nodes,
-                this.superNetwork.links,
-                superNode,
+              this.$emit(
+                'updateNetwork',
+                expandSuperNetwork(
+                  this.nonAggrNodes,
+                  this.nonAggrLinks,
+                  this.network.nodes,
+                  this.network.links,
+                  superNode,
+                ),
               );
               this.clickMap.set(d.id, true);
               console.log('click map state: ', this.clickMap);
               // print the new supernetwork
               console.log('print the super network');
-              console.log(this.superNetwork);
+              console.log(this.network);
             }
             // if the selected node is not in the map
             // add it to the map and visualize the expansion
@@ -655,16 +664,19 @@ export default Vue.extend({
               console.log('the click map has no nodes expanded');
               this.clickMap.set(d.id, true);
               console.log('expand the visualization');
-              this.superNetwork = expandSuperNetwork(
-                this.nonAggrNodes,
-                this.nonAggrLinks,
-                this.network.nodes,
-                this.network.links,
-                superNode,
+              this.$emit(
+                'updateNetwork',
+                expandSuperNetwork(
+                  this.nonAggrNodes,
+                  this.nonAggrLinks,
+                  this.network.nodes,
+                  this.network.links,
+                  superNode,
+                ),
               );
               // print the new supernetwork
               console.log('print the super network');
-              console.log(this.superNetwork);
+              console.log(this.network);
               console.log('click map state: ', this.clickMap);
             }
           } else {

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -612,14 +612,14 @@ export default Vue.extend({
             }
             // variable for keeping track of the supernode selected
             const supernode = d;
-            console.log('supernode selected: ', supernode.id);
+            // console.log('supernode selected: ', supernode.id);
 
             // different cases for expanding and retracting the visualization
             if (this.clickMap.has(supernode.id)) {
               // if the dictionary contains the supernode two cases
               // CASE 1: TRUE -> RETRACT THE NETWORK
               if (this.clickMap.get(supernode.id) === true) {
-                console.log('retract supernode children');
+                // console.log('retract supernode children');
                 this.$emit(
                   'updateNetwork',
                   retractSuperNetwork(
@@ -631,9 +631,9 @@ export default Vue.extend({
                   ),
                 );
                 this.clickMap.set(supernode.id, false);
-                console.log('vis state', this.clickMap);
+                // console.log('vis state', this.clickMap);
               } else {
-                console.log('expand the supernode and its children');
+                // console.log('expand the supernode and its children');
                 this.$emit(
                   'updateNetwork',
                   expandSuperNetwork(
@@ -645,14 +645,14 @@ export default Vue.extend({
                   ),
                 );
                 this.clickMap.set(supernode.id, true);
-                console.log('vis state', this.clickMap);
+                // console.log('vis state', this.clickMap);
               }
             } else {
-              console.log(
-                'click map does not contain supernode: ',
-                supernode.id,
-              );
-              console.log('vis state', this.clickMap);
+              // console.log(
+              //   'click map does not contain supernode: ',
+              //   supernode.id,
+              // );
+              // console.log('vis state', this.clickMap);
               this.$emit(
                 'updateNetwork',
                 expandSuperNetwork(
@@ -664,7 +664,7 @@ export default Vue.extend({
                 ),
               );
               this.clickMap.set(supernode.id, true);
-              console.log('click map state: ', this.clickMap);
+              // console.log('click map state: ', this.clickMap);
             }
           } else {
             this.selectElement(d);
@@ -922,8 +922,8 @@ export default Vue.extend({
           if (this.enableGraffinity) {
             this.nonAggrNodes = this.processChildNodes(this.network.nodes);
             this.nonAggrLinks = this.processChildLinks(this.network.links);
-            console.log('nodes before aggregation', this.nonAggrNodes);
-            console.log('links before aggregation', this.nonAggrLinks);
+            // console.log('nodes before aggregation', this.nonAggrNodes);
+            // console.log('links before aggregation', this.nonAggrLinks);
             // this.network = superGraph(this.network.nodes, this.network.links, d);
             this.$emit(
               'updateNetwork',

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -49,7 +49,7 @@ export default Vue.extend({
   },
 
   data(): {
-    // superNetwork: Network;
+    superNetwork: Network;
     browser: Dimensions;
     visMargins: any;
     matrixSVG: any;
@@ -77,12 +77,14 @@ export default Vue.extend({
     nonAggrNodes: any;
     nonAggrLinks: any;
     clickMap: any; // variable for keeping track of whether a label has been clicked or not
+    expandRetractAggrVisNodes: any; // variable for keeping track of the current nodes being visualized
+    expandRetractAggrVisLinks: any; // variable for keeping track of the current links being visualized
   } {
     return {
-      // superNetwork: {
-      //   nodes: [],
-      //   links: [],
-      // },
+      superNetwork: {
+        nodes: [],
+        links: [],
+      },
 
       browser: {
         height: 0,
@@ -105,6 +107,8 @@ export default Vue.extend({
       clickMap: undefined,
       nonAggrNodes: undefined,
       nonAggrLinks: undefined,
+      expandRetractAggrVisNodes: undefined,
+      expandRetractAggrVisLinks: undefined,
       icons: {
         quant: {
           d:
@@ -597,11 +601,11 @@ export default Vue.extend({
           this.hideToolTip();
           this.unHoverNode(d.id);
         })
-        .on('click', (d: Node, i: number) => {
+        .on('click', (d: Node) => {
           if (this.enableGraffinity) {
             // create a new dictionary that checks whether a node has been clicked for
             // expanding or retracting the matrix vis
-            console.log('id and number selected: ', d.id, i);
+            console.log('id and number selected: ', d.id);
             if (d.type === 'node') {
               return;
             }
@@ -609,31 +613,66 @@ export default Vue.extend({
             // console.log('node value: ', d);
 
             if (this.clickMap.has(d.id)) {
-              // console.log("selection is in the map");
               if (this.clickMap.get(d.id) === true) {
                 console.log('retract visualization');
-                console.log("network before retraction", this.network);
-                retractSuperNetwork(
-                  this.nonAggrNodes,
-                  this.nonAggrLinks,
-                  this.network.nodes,
-                  this.network.links,
-                  superNode,
-                );
-                this.clickMap.set(d.id, false);
-                console.log("retracted network", this.network);
-                console.log('click map state: ', this.clickMap);
-              } else {
-                console.log('expand visualization');
-                this.$emit(
-                  'updateNetwork',
-                  expandSuperNetwork(
+                console.log(
+                  'retracted network',
+                  retractSuperNetwork(
                     this.nonAggrNodes,
                     this.nonAggrLinks,
-                    this.network.nodes,
+                    this.superNetwork.nodes,
                     this.network.links,
                     superNode,
                   ),
+                );
+                // this.$emit(
+                //   'updateNetwork',
+                //   retractSuperNetwork(
+                //     this.nonAggrNodes,
+                //     this.nonAggrLinks,
+                //     this.superNetwork.nodes,
+                //     this.superNetwork.links,
+                //     superNode,
+                //   ),
+                // );
+                this.superNetwork = retractSuperNetwork(
+                  this.nonAggrNodes,
+                  this.nonAggrLinks,
+                  this.superNetwork.nodes,
+                  this.superNetwork.links,
+                  superNode,
+                );
+                this.clickMap.set(d.id, false);
+                // console.log('retracted network', this.network);
+                console.log('click map state: ', this.clickMap);
+              } else {
+                console.log('expand visualization');
+                // this.$emit(
+                //   'updateNetwork',
+                //   expandSuperNetwork(
+                //     this.nonAggrNodes,
+                //     this.nonAggrLinks,
+                //     this.superNetwork.nodes,
+                //     this.superNetwork.links,
+                //     superNode,
+                //   ),
+                // );
+                console.log(
+                  'expand network',
+                  expandSuperNetwork(
+                    this.nonAggrNodes,
+                    this.nonAggrLinks,
+                    this.superNetwork.nodes,
+                    this.network.links,
+                    superNode,
+                  ),
+                );
+                this.superNetwork = expandSuperNetwork(
+                  this.nonAggrNodes,
+                  this.nonAggrLinks,
+                  this.superNetwork.nodes,
+                  this.superNetwork.links,
+                  superNode,
                 );
                 this.clickMap.set(d.id, true);
                 console.log('click map state: ', this.clickMap);
@@ -643,22 +682,36 @@ export default Vue.extend({
             else if (this.clickMap.size != 0) {
               console.log('the click map has at least one node expanded');
               console.log('expand visualization');
-              console.log('agg network before expansion', this.network);
-              this.$emit(
-                'updateNetwork',
+              console.log('network before expansion', this.network);
+              // this.$emit(
+              //   'updateNetwork',
+              //   expandSuperNetwork(
+              //     this.nonAggrNodes,
+              //     this.nonAggrLinks,
+              //     this.superNetwork.nodes,
+              //     this.superNetwork.links,
+              //     superNode,
+              //   ),
+              // );
+              console.log(
+                'expand network',
                 expandSuperNetwork(
                   this.nonAggrNodes,
                   this.nonAggrLinks,
-                  this.network.nodes,
+                  this.superNetwork.nodes,
                   this.network.links,
                   superNode,
                 ),
               );
+              this.superNetwork = expandSuperNetwork(
+                this.nonAggrNodes,
+                this.nonAggrLinks,
+                this.superNetwork.nodes,
+                this.superNetwork.links,
+                superNode,
+              );
               this.clickMap.set(d.id, true);
               console.log('click map state: ', this.clickMap);
-              // print the new supernetwork
-              console.log('print the new network after expansion');
-              console.log(this.network);
             }
             // if the selected node is not in the map
             // add it to the map and visualize the expansion
@@ -668,8 +721,19 @@ export default Vue.extend({
               this.clickMap.set(d.id, true);
               console.log('expand the visualization');
               console.log('agg network before expansion', this.network);
-              this.$emit(
-                'updateNetwork',
+              this.superNetwork = expandSuperNetwork(
+                this.nonAggrNodes,
+                this.nonAggrLinks,
+                this.network.nodes,
+                this.network.links,
+                superNode,
+              );
+              console.log(
+                'the super network after expansion: ',
+                this.superNetwork,
+              );
+              console.log(
+                'expanded network',
                 expandSuperNetwork(
                   this.nonAggrNodes,
                   this.nonAggrLinks,
@@ -678,9 +742,15 @@ export default Vue.extend({
                   superNode,
                 ),
               );
-              // print the new supernetwork
-              console.log('new network');
-              console.log(this.network);
+              // this.$emit(
+              //   'updateNetwork',
+              //   expandSuperNetwork(
+              //     this.nonAggrNodes,
+              //     this.nonAggrLinks,
+              //     this.network.nodes,
+              //     this.network.links,
+              //     superNode,
+              //   ),);
               console.log('click map state: ', this.clickMap);
             }
           } else {

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -49,7 +49,7 @@ export default Vue.extend({
   },
 
   data(): {
-    // superNetwork: Network;
+    superNetwork: Network;
     browser: Dimensions;
     visMargins: any;
     matrixSVG: any;
@@ -79,10 +79,10 @@ export default Vue.extend({
     clickMap: any; // variable for keeping track of whether a label has been clicked or not
   } {
     return {
-      // superNetwork: {
-      //   nodes: [],
-      //   links: [],
-      // },
+      superNetwork: {
+        nodes: [],
+        links: [],
+      },
 
       browser: {
         height: 0,
@@ -602,6 +602,7 @@ export default Vue.extend({
             // create a new dictionary that checks whether a node has been clicked for
             // expanding or retracting the matrix vis
             console.log('id and number selected: ', d.id, i);
+            const superNode = d;
             // console.log('node value: ', d);
 
             if (this.clickMap.has(d.id)) {
@@ -618,28 +619,50 @@ export default Vue.extend({
                 console.log('click map state: ', this.clickMap);
               } else {
                 console.log('expand visualization');
-                expandSuperNetwork(
+                this.superNetwork = expandSuperNetwork(
                   this.nonAggrNodes,
                   this.nonAggrLinks,
-                  this.network.nodes,
-                  this.network.links,
+                  this.superNetwork.nodes,
+                  this.superNetwork.links,
+                  superNode,
                 );
                 this.clickMap.set(d.id, true);
                 console.log('click map state: ', this.clickMap);
               }
+            } else if (this.clickMap.size != 0) {
+              console.log("the click map has at least one node expanded");
+              console.log('expand visualization');
+              this.superNetwork = expandSuperNetwork(
+                this.nonAggrNodes,
+                this.nonAggrLinks,
+                this.superNetwork.nodes,
+                this.superNetwork.links,
+                superNode,
+              );
+              this.clickMap.set(d.id, true);
+              console.log('click map state: ', this.clickMap);
+              // print the new supernetwork
+              console.log('print the super network');
+              console.log(this.superNetwork);
             }
             // if the selected node is not in the map
             // add it to the map and visualize the expansion
             else {
               // console.log("new selection");
+              console.log("the click map has no nodes expanded");
               this.clickMap.set(d.id, true);
               console.log('expand the visualization');
-              expandSuperNetwork(
+              this.superNetwork = expandSuperNetwork(
                 this.nonAggrNodes,
                 this.nonAggrLinks,
                 this.network.nodes,
                 this.network.links,
+                superNode,
               );
+
+              // print the new supernetwork
+              console.log('print the super network');
+              console.log(this.superNetwork);
               console.log('click map state: ', this.clickMap);
             }
           } else {

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -294,13 +294,9 @@ export default Vue.extend({
     },
 
     processData(): void {
-      // console.log("matrix info", this.matrix);
       this.matrix = [];
       this.network.nodes.forEach((rowNode: Node, i: number) => {
-        // console.log("rowNode: ", rowNode.id);
-
         this.matrix[i] = this.network.nodes.map((colNode: Node) => {
-          // console.log("colNode: ", colNode.id);
           return {
             cellName: `${rowNode.id}_${colNode.id}`,
             correspondingCell: `${colNode.id}_${rowNode.id}`,
@@ -610,16 +606,10 @@ export default Vue.extend({
             if (d.type === 'node') {
               return;
             }
-            // variable for keeping track of the supernode selected
             const supernode = d;
-            // console.log('supernode selected: ', supernode.id);
-
-            // different cases for expanding and retracting the visualization
+         // expand and retract the supernode aggregation based on user selection
             if (this.clickMap.has(supernode.id)) {
-              // if the dictionary contains the supernode two cases
-              // CASE 1: TRUE -> RETRACT THE NETWORK
               if (this.clickMap.get(supernode.id) === true) {
-                // console.log('retract supernode children');
                 this.$emit(
                   'updateNetwork',
                   retractSuperNetwork(
@@ -631,9 +621,7 @@ export default Vue.extend({
                   ),
                 );
                 this.clickMap.set(supernode.id, false);
-                // console.log('vis state', this.clickMap);
               } else {
-                // console.log('expand the supernode and its children');
                 this.$emit(
                   'updateNetwork',
                   expandSuperNetwork(
@@ -645,14 +633,8 @@ export default Vue.extend({
                   ),
                 );
                 this.clickMap.set(supernode.id, true);
-                // console.log('vis state', this.clickMap);
               }
             } else {
-              // console.log(
-              //   'click map does not contain supernode: ',
-              //   supernode.id,
-              // );
-              // console.log('vis state', this.clickMap);
               this.$emit(
                 'updateNetwork',
                 expandSuperNetwork(
@@ -663,8 +645,7 @@ export default Vue.extend({
                   supernode,
                 ),
               );
-              this.clickMap.set(supernode.id, true);
-              // console.log('click map state: ', this.clickMap);
+              this.clickMap.set(supernode.id, true);;
             }
           } else {
             this.selectElement(d);
@@ -922,9 +903,6 @@ export default Vue.extend({
           if (this.enableGraffinity) {
             this.nonAggrNodes = this.processChildNodes(this.network.nodes);
             this.nonAggrLinks = this.processChildLinks(this.network.links);
-            // console.log('nodes before aggregation', this.nonAggrNodes);
-            // console.log('links before aggregation', this.nonAggrLinks);
-            // this.network = superGraph(this.network.nodes, this.network.links, d);
             this.$emit(
               'updateNetwork',
               superGraph(this.network.nodes, this.network.links, d),

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -3,7 +3,7 @@ import Vue, { PropType } from 'vue';
 
 import {
   superGraph,
-  // expandSuperNetwork,
+  expandSuperNetwork,
   // retractSuperNetwork,
 } from '@/lib/aggregation';
 import { Cell, Dimensions, Link, Network, Node, State } from '@/types';
@@ -616,6 +616,36 @@ export default Vue.extend({
             // variable for keeping track of the supernode selected
             const supernode = d;
             console.log('supernode selected: ', supernode.id);
+
+            // different cases for expanding and retracting the visualization
+            if (this.clickMap.has(supernode.id)) {
+              // if the dictionary contains the supernode two cases
+              // CASE 1: TRUE -> RETRACT THE NETWORK
+              if (this.clickMap.get(supernode.id) === true) {
+                console.log('retract supernode children');
+                this.clickMap.set(supernode.id, false);
+                console.log('vis state', this.clickMap);
+              } else {
+                console.log('expand the supernode and its children');
+                this.clickMap.set(supernode.id, true);
+                console.log('vis state', this.clickMap);
+              }
+            } else {
+              console.log(' the click map has no entries');
+              this.clickMap.set(supernode.id, true);
+              console.log('vis state', this.clickMap);
+              this.$emit(
+                'updateNetwork',
+                expandSuperNetwork(
+                  this.nonAggrNodes,
+                  this.nonAggrLinks,
+                  this.network.nodes,
+                  this.network.links,
+                  supernode,
+                ),
+              );
+              // console.log('click map state: ', this.clickMap);
+            }
           } else {
             this.selectElement(d);
             this.selectNeighborNodes(d.id, d.neighbors);

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -249,7 +249,7 @@ export default Vue.extend({
     },
 
     changeMatrix(this: any) {
-      select('#matrix').selectAll('*').remove();
+      // select('#matrix').selectAll('*').remove();
 
       this.browser.width =
         window.innerWidth ||
@@ -630,10 +630,11 @@ export default Vue.extend({
                 this.clickMap.set(supernode.id, true);
                 console.log('vis state', this.clickMap);
               }
-            } else {
+            }
+            else {
               console.log(' the click map has no entries');
               this.clickMap.set(supernode.id, true);
-              console.log('vis state', this.clickMap);
+              console.log("vis state", this.clickMap);
               this.$emit(
                 'updateNetwork',
                 expandSuperNetwork(
@@ -646,6 +647,8 @@ export default Vue.extend({
               );
               // console.log('click map state: ', this.clickMap);
             }
+
+        
           } else {
             this.selectElement(d);
             this.selectNeighborNodes(d.id, d.neighbors);

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -612,6 +612,7 @@ export default Vue.extend({
               // console.log("selection is in the map");
               if (this.clickMap.get(d.id) === true) {
                 console.log('retract visualization');
+                console.log("network before retraction", this.network);
                 retractSuperNetwork(
                   this.nonAggrNodes,
                   this.nonAggrLinks,
@@ -620,6 +621,7 @@ export default Vue.extend({
                   superNode,
                 );
                 this.clickMap.set(d.id, false);
+                console.log("retracted network", this.network);
                 console.log('click map state: ', this.clickMap);
               } else {
                 console.log('expand visualization');
@@ -641,6 +643,7 @@ export default Vue.extend({
             else if (this.clickMap.size != 0) {
               console.log('the click map has at least one node expanded');
               console.log('expand visualization');
+              console.log('agg network before expansion', this.network);
               this.$emit(
                 'updateNetwork',
                 expandSuperNetwork(
@@ -654,7 +657,7 @@ export default Vue.extend({
               this.clickMap.set(d.id, true);
               console.log('click map state: ', this.clickMap);
               // print the new supernetwork
-              console.log('print the super network');
+              console.log('print the new network after expansion');
               console.log(this.network);
             }
             // if the selected node is not in the map
@@ -664,6 +667,7 @@ export default Vue.extend({
               console.log('the click map has no nodes expanded');
               this.clickMap.set(d.id, true);
               console.log('expand the visualization');
+              console.log('agg network before expansion', this.network);
               this.$emit(
                 'updateNetwork',
                 expandSuperNetwork(
@@ -675,7 +679,7 @@ export default Vue.extend({
                 ),
               );
               // print the new supernetwork
-              console.log('print the super network');
+              console.log('new network');
               console.log(this.network);
               console.log('click map state: ', this.clickMap);
             }

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -68,11 +68,11 @@ export default Vue.extend({
     edgeColumns: any;
     edgeRows: any;
     cells: any;
-    clickMap: any; // variable for keeping track of whether a label has been clicked or not
-    nonAggrNodes: any;
-    nonAggrLinks: any;
-    expandRetractAggrVisNodes: any; // variable for keeping track of the current nodes being visualized
-    expandRetractAggrVisLinks: any; // variable for keeping track of the current links being visualized
+    clickMap: Map<string, boolean>; // variable for keeping track of whether a label has been clicked or not
+    nonAggrNodes: Node[];
+    nonAggrLinks: Link[];
+    expandRetractAggrVisNodes: Network; // variable for keeping track of the current nodes being visualized
+    expandRetractAggrVisLinks: Network; // variable for keeping track of the current links being visualized
     icons: { [key: string]: { [d: string]: string } };
     selectedNodesAndNeighbors: { [key: string]: string[] };
     selectedElements: { [key: string]: string[] };
@@ -101,11 +101,17 @@ export default Vue.extend({
       edgeColumns: undefined,
       edgeRows: undefined,
       cells: undefined,
-      clickMap: undefined,
-      nonAggrNodes: undefined,
-      nonAggrLinks: undefined,
-      expandRetractAggrVisNodes: undefined,
-      expandRetractAggrVisLinks: undefined,
+      clickMap: new Map<string, boolean>(),
+      nonAggrNodes: [],
+      nonAggrLinks: [],
+      expandRetractAggrVisNodes: {
+        nodes: [],
+        links: [],
+      },
+      expandRetractAggrVisLinks: {
+        nodes: [],
+        links: [],
+      },
       icons: {
         quant: {
           d:
@@ -1072,8 +1078,6 @@ export default Vue.extend({
               'updateNetwork',
               superGraph(this.network.nodes, this.network.links, d),
             );
-            // create a new instant of click map for keeping track of the nodes that the user has selected
-            this.clickMap = new Map<string, boolean>();
           } else {
             this.sort(d);
           }

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -612,8 +612,9 @@ export default Vue.extend({
                 retractSuperNetwork(
                   this.nonAggrNodes,
                   this.nonAggrLinks,
-                  this.network.nodes,
-                  this.network.links,
+                  this.superNetwork.nodes,
+                  this.superNetwork.links,
+                  superNode,
                 );
                 this.clickMap.set(d.id, false);
                 console.log('click map state: ', this.clickMap);
@@ -629,8 +630,10 @@ export default Vue.extend({
                 this.clickMap.set(d.id, true);
                 console.log('click map state: ', this.clickMap);
               }
-            } else if (this.clickMap.size != 0) {
-              console.log("the click map has at least one node expanded");
+            }
+            // case when there is at least one expand supernode in the click map
+            else if (this.clickMap.size != 0) {
+              console.log('the click map has at least one node expanded');
               console.log('expand visualization');
               this.superNetwork = expandSuperNetwork(
                 this.nonAggrNodes,
@@ -649,7 +652,7 @@ export default Vue.extend({
             // add it to the map and visualize the expansion
             else {
               // console.log("new selection");
-              console.log("the click map has no nodes expanded");
+              console.log('the click map has no nodes expanded');
               this.clickMap.set(d.id, true);
               console.log('expand the visualization');
               this.superNetwork = expandSuperNetwork(
@@ -659,7 +662,6 @@ export default Vue.extend({
                 this.network.links,
                 superNode,
               );
-
               // print the new supernetwork
               console.log('print the super network');
               console.log(this.superNetwork);

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -249,7 +249,7 @@ export default Vue.extend({
     },
 
     changeMatrix(this: any) {
-      // select('#matrix').selectAll('*').remove();
+      select('#matrix').selectAll('*').remove();
 
       this.browser.width =
         window.innerWidth ||

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -634,6 +634,16 @@ export default Vue.extend({
                 console.log('vis state', this.clickMap);
               } else {
                 console.log('expand the supernode and its children');
+                this.$emit(
+                  'updateNetwork',
+                  expandSuperNetwork(
+                    this.nonAggrNodes,
+                    this.nonAggrLinks,
+                    this.network.nodes,
+                    this.network.links,
+                    supernode,
+                  ),
+                );
                 this.clickMap.set(supernode.id, true);
                 console.log('vis state', this.clickMap);
               }
@@ -642,7 +652,6 @@ export default Vue.extend({
                 'click map does not contain supernode: ',
                 supernode.id,
               );
-              this.clickMap.set(supernode.id, true);
               console.log('vis state', this.clickMap);
               this.$emit(
                 'updateNetwork',
@@ -654,6 +663,7 @@ export default Vue.extend({
                   supernode,
                 ),
               );
+              this.clickMap.set(supernode.id, true);
               console.log('click map state: ', this.clickMap);
             }
           } else {

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -196,9 +196,6 @@ export default Vue.extend({
       this.processData();
       this.changeMatrix();
     },
-    // superNetwork() {
-    //   console.log('do something with the network');
-    // },
   },
 
   async mounted(this: any) {

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -527,7 +527,6 @@ export default Vue.extend({
             // expand and retract the supernode aggregation based on user selection
             if (this.clickMap.has(supernode.id)) {
               if (this.clickMap.get(supernode.id) === true) {
-                // console.log("retract the super network when the selection is in the click");
                 this.$emit(
                   'updateNetwork',
                   retractSuperNetwork(
@@ -540,7 +539,6 @@ export default Vue.extend({
                 );
                 this.clickMap.set(supernode.id, false);
               } else {
-                // console.log("expand the super network when the selection is in the click map");
                 this.$emit(
                   'updateNetwork',
                   expandSuperNetwork(

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -3,8 +3,8 @@ import Vue, { PropType } from 'vue';
 
 import {
   superGraph,
-  expandSuperNetwork,
-  retractSuperNetwork,
+  // expandSuperNetwork,
+  // retractSuperNetwork,
 } from '@/lib/aggregation';
 import { Cell, Dimensions, Link, Network, Node, State } from '@/types';
 import {
@@ -157,7 +157,7 @@ export default Vue.extend({
         this.matrixNodeLength * this.cellSize +
         this.visMargins.left +
         this.visMargins.right
-      ) ;
+      );
     },
 
     matrixHeight(): number {
@@ -262,8 +262,6 @@ export default Vue.extend({
         document.body.clientHeight;
 
       // Size the svgs
-      console.log("matrix node length");
-      console.log(this.network.nodes.length);
       this.matrixSVG = select(this.$refs.matrix)
         .attr('width', this.matrixWidth)
         .attr('height', this.matrixHeight)
@@ -302,10 +300,10 @@ export default Vue.extend({
       // console.log("matrix info", this.matrix);
       this.matrix = [];
       this.network.nodes.forEach((rowNode: Node, i: number) => {
-        console.log("rowNode: ", rowNode.id);
+        // console.log("rowNode: ", rowNode.id);
 
         this.matrix[i] = this.network.nodes.map((colNode: Node) => {
-          console.log("colNode: ", colNode.id);
+          // console.log("colNode: ", colNode.id);
           return {
             cellName: `${rowNode.id}_${colNode.id}`,
             correspondingCell: `${colNode.id}_${rowNode.id}`,
@@ -332,8 +330,6 @@ export default Vue.extend({
           }
         });
       });
-      console.log("the matrix");
-      console.log(this.matrix);
     },
 
     setUpProvenance(): any {
@@ -611,157 +607,15 @@ export default Vue.extend({
           this.unHoverNode(d.id);
         })
         .on('click', (d: Node) => {
+          // allow expanding the vis if graffinity features are on
           if (this.enableGraffinity) {
-            // create a new dictionary that checks whether a node has been clicked for
-            // expanding or retracting the matrix vis
-            console.log('id and number selected: ', d.id);
+            // if user selects a child node don't do anything
             if (d.type === 'node') {
               return;
             }
-            const superNode = d;
-            // console.log('node value: ', d);
-
-            if (this.clickMap.has(d.id)) {
-              if (this.clickMap.get(d.id) === true) {
-                console.log('retract visualization');
-                console.log(
-                  'retracted network',
-                  retractSuperNetwork(
-                    this.nonAggrNodes,
-                    this.nonAggrLinks,
-                    this.superNetwork.nodes,
-                    this.network.links,
-                    superNode,
-                  ),
-                );
-                // this.$emit(
-                //   'updateNetwork',
-                //   retractSuperNetwork(
-                //     this.nonAggrNodes,
-                //     this.nonAggrLinks,
-                //     this.superNetwork.nodes,
-                //     this.superNetwork.links,
-                //     superNode,
-                //   ),
-                // );
-                this.superNetwork = retractSuperNetwork(
-                  this.nonAggrNodes,
-                  this.nonAggrLinks,
-                  this.superNetwork.nodes,
-                  this.superNetwork.links,
-                  superNode,
-                );
-                this.clickMap.set(d.id, false);
-                // console.log('retracted network', this.network);
-                console.log('click map state: ', this.clickMap);
-              } else {
-                console.log('expand visualization');
-                // this.$emit(
-                //   'updateNetwork',
-                //   expandSuperNetwork(
-                //     this.nonAggrNodes,
-                //     this.nonAggrLinks,
-                //     this.superNetwork.nodes,
-                //     this.superNetwork.links,
-                //     superNode,
-                //   ),
-                // );
-                console.log(
-                  'expand network',
-                  expandSuperNetwork(
-                    this.nonAggrNodes,
-                    this.nonAggrLinks,
-                    this.superNetwork.nodes,
-                    this.network.links,
-                    superNode,
-                  ),
-                );
-                this.superNetwork = expandSuperNetwork(
-                  this.nonAggrNodes,
-                  this.nonAggrLinks,
-                  this.superNetwork.nodes,
-                  this.superNetwork.links,
-                  superNode,
-                );
-                this.clickMap.set(d.id, true);
-                console.log('click map state: ', this.clickMap);
-              }
-            }
-            // case when there is at least one expand supernode in the click map
-            else if (this.clickMap.size != 0) {
-              // console.log('the click map has at least one node expanded');
-              // console.log('expand visualization');
-              // console.log('network before expansion', this.network);
-              this.$emit(
-                'updateNetwork',
-                expandSuperNetwork(
-                  this.nonAggrNodes,
-                  this.nonAggrLinks,
-                  this.superNetwork.nodes,
-                  this.superNetwork.links,
-                  superNode,
-                ),
-              );
-              // console.log(
-              //   'expand network',
-              //   expandSuperNetwork(
-              //     this.nonAggrNodes,
-              //     this.nonAggrLinks,
-              //     this.superNetwork.nodes,
-              //     this.network.links,
-              //     superNode,
-              //   ),
-              // );
-              this.superNetwork = expandSuperNetwork(
-                this.nonAggrNodes,
-                this.nonAggrLinks,
-                this.superNetwork.nodes,
-                this.superNetwork.links,
-                superNode,
-              );
-              this.clickMap.set(d.id, true);
-              console.log('click map state: ', this.clickMap);
-            }
-            // if the selected node is not in the map
-            // add it to the map and visualize the expansion
-            else {
-              // // console.log("new selection");
-              // console.log('the click map has no nodes expanded');
-              // this.clickMap.set(d.id, true);
-              // console.log('expand the visualization');
-              // console.log('agg network before expansion', this.network);
-              // this.superNetwork = expandSuperNetwork(
-              //   this.nonAggrNodes,
-              //   this.nonAggrLinks,
-              //   this.network.nodes,
-              //   this.network.links,
-              //   superNode,
-              // );
-              // console.log(
-              //   'the super network after expansion: ',
-              //   this.superNetwork,
-              // );
-              // console.log(
-              //   'expanded network',
-              //   expandSuperNetwork(
-              //     this.nonAggrNodes,
-              //     this.nonAggrLinks,
-              //     this.network.nodes,
-              //     this.network.links,
-              //     superNode,
-              //   ),
-              // );
-              this.$emit(
-                'updateNetwork',
-                expandSuperNetwork(
-                  this.nonAggrNodes,
-                  this.nonAggrLinks,
-                  this.network.nodes,
-                  this.network.links,
-                  superNode,
-                ),);
-              console.log('click map state: ', this.clickMap);
-            }
+            // variable for keeping track of the supernode selected
+            const supernode = d;
+            console.log('supernode selected: ', supernode.id);
           } else {
             this.selectElement(d);
             this.selectNeighborNodes(d.id, d.neighbors);

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -53,7 +53,6 @@ export default Vue.extend({
   },
 
   data(): {
-    superNetwork: Network;
     browser: Dimensions;
     visMargins: any;
     matrixSVG: any;
@@ -69,6 +68,11 @@ export default Vue.extend({
     edgeColumns: any;
     edgeRows: any;
     cells: any;
+    clickMap: any; // variable for keeping track of whether a label has been clicked or not
+    nonAggrNodes: any;
+    nonAggrLinks: any;
+    expandRetractAggrVisNodes: any; // variable for keeping track of the current nodes being visualized
+    expandRetractAggrVisLinks: any; // variable for keeping track of the current links being visualized
     icons: { [key: string]: { [d: string]: string } };
     selectedNodesAndNeighbors: { [key: string]: string[] };
     selectedElements: { [key: string]: string[] };
@@ -77,18 +81,8 @@ export default Vue.extend({
     provenance: any;
     sortKey: string;
     colMargin: number;
-    nonAggrNodes: any;
-    nonAggrLinks: any;
-    clickMap: any; // variable for keeping track of whether a label has been clicked or not
-    expandRetractAggrVisNodes: any; // variable for keeping track of the current nodes being visualized
-    expandRetractAggrVisLinks: any; // variable for keeping track of the current links being visualized
   } {
     return {
-      superNetwork: {
-        nodes: [],
-        links: [],
-      },
-
       browser: {
         height: 0,
         width: 0,

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -561,7 +561,6 @@ export default Vue.extend({
             }
             const supernode = d;
             // expand and retract the supernode aggregation based on user selection
-            if (this.clickMap.has(supernode.id)) {
               if (this.clickMap.get(supernode.id)) {
                 this.$emit(
                   'updateNetwork',
@@ -587,19 +586,6 @@ export default Vue.extend({
                 );
                 this.clickMap.set(supernode.id, true);
               }
-            } else {
-              this.$emit(
-                'updateNetwork',
-                expandSuperNetwork(
-                  this.nonAggrNodes,
-                  this.nonAggrLinks,
-                  this.network.nodes,
-                  this.network.links,
-                  supernode,
-                ),
-              );
-              this.clickMap.set(supernode.id, true);
-            }
           } else {
             this.selectElement(d);
             this.selectNeighborNodes(d.id, d.neighbors);

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -1,7 +1,11 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 
-import { superGraph } from '@/lib/aggregation';
+import {
+  superGraph,
+  expandSuperNetwork,
+  retractSuperNetwork,
+} from '@/lib/aggregation';
 import { Cell, Dimensions, Link, Network, Node, State } from '@/types';
 import {
   axisTop,
@@ -45,6 +49,7 @@ export default Vue.extend({
   },
 
   data(): {
+    // superNetwork: Network;
     browser: Dimensions;
     visMargins: any;
     matrixSVG: any;
@@ -74,6 +79,11 @@ export default Vue.extend({
     clickMap: any; // variable for keeping track of whether a label has been clicked or not
   } {
     return {
+      // superNetwork: {
+      //   nodes: [],
+      //   links: [],
+      // },
+
       browser: {
         height: 0,
         width: 0,
@@ -181,6 +191,9 @@ export default Vue.extend({
       this.generateIdMap();
       this.processData();
       this.changeMatrix();
+    },
+    superNetwork() {
+      console.log('do something with the network');
     },
   },
 
@@ -366,8 +379,8 @@ export default Vue.extend({
         .attr('transform', `translate(0, 0)`);
 
       this.edgeRows
-        .transition()
-        .duration(1100)
+        // .transition()
+        // .duration(1100)
         .attr('transform', (d: Node, i: number) => {
           return `translate(0,${this.orderingScale(i)})`;
         });
@@ -589,16 +602,28 @@ export default Vue.extend({
             // create a new dictionary that checks whether a node has been clicked for
             // expanding or retracting the matrix vis
             console.log('id and number selected: ', d.id, i);
-            console.log('node value: ', d);
+            // console.log('node value: ', d);
 
             if (this.clickMap.has(d.id)) {
               // console.log("selection is in the map");
               if (this.clickMap.get(d.id) === true) {
                 console.log('retract visualization');
+                retractSuperNetwork(
+                  this.nonAggrNodes,
+                  this.nonAggrLinks,
+                  this.network.nodes,
+                  this.network.links,
+                );
                 this.clickMap.set(d.id, false);
                 console.log('click map state: ', this.clickMap);
               } else {
                 console.log('expand visualization');
+                expandSuperNetwork(
+                  this.nonAggrNodes,
+                  this.nonAggrLinks,
+                  this.network.nodes,
+                  this.network.links,
+                );
                 this.clickMap.set(d.id, true);
                 console.log('click map state: ', this.clickMap);
               }
@@ -609,6 +634,12 @@ export default Vue.extend({
               // console.log("new selection");
               this.clickMap.set(d.id, true);
               console.log('expand the visualization');
+              expandSuperNetwork(
+                this.nonAggrNodes,
+                this.nonAggrLinks,
+                this.network.nodes,
+                this.network.links,
+              );
               console.log('click map state: ', this.clickMap);
             }
           } else {
@@ -869,10 +900,12 @@ export default Vue.extend({
             this.nonAggrLinks = this.processChildLinks(this.network.links);
             console.log('nodes before aggregation', this.nonAggrNodes);
             console.log('links before aggregation', this.nonAggrLinks);
+            // this.network = superGraph(this.network.nodes, this.network.links, d);
             this.$emit(
               'updateNetwork',
               superGraph(this.network.nodes, this.network.links, d),
             );
+            // create a new instant of click map for keeping track of the nodes that the user has selected
             this.clickMap = new Map<string, boolean>();
           } else {
             this.sort(d);

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -484,8 +484,8 @@ export default Vue.extend({
         .attr('transform', `translate(0, 0)`);
 
       rowEnter
-        // .transition()
-        // .duration(1100)
+        .transition()
+        .duration(1100)
         .attr('transform', (d: Node, i: number) => {
           return `translate(0,${this.orderingScale(i)})`;
         });

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -4,7 +4,7 @@ import Vue, { PropType } from 'vue';
 import {
   superGraph,
   expandSuperNetwork,
-  // retractSuperNetwork,
+  retractSuperNetwork,
 } from '@/lib/aggregation';
 import { Cell, Dimensions, Link, Network, Node, State } from '@/types';
 import {
@@ -620,6 +620,16 @@ export default Vue.extend({
               // CASE 1: TRUE -> RETRACT THE NETWORK
               if (this.clickMap.get(supernode.id) === true) {
                 console.log('retract supernode children');
+                this.$emit(
+                  'updateNetwork',
+                  retractSuperNetwork(
+                    this.nonAggrNodes,
+                    this.nonAggrLinks,
+                    this.network.nodes,
+                    this.network.links,
+                    supernode,
+                  ),
+                );
                 this.clickMap.set(supernode.id, false);
                 console.log('vis state', this.clickMap);
               } else {
@@ -627,11 +637,13 @@ export default Vue.extend({
                 this.clickMap.set(supernode.id, true);
                 console.log('vis state', this.clickMap);
               }
-            }
-            else {
-              console.log(' the click map has no entries');
+            } else {
+              console.log(
+                'click map does not contain supernode: ',
+                supernode.id,
+              );
               this.clickMap.set(supernode.id, true);
-              console.log("vis state", this.clickMap);
+              console.log('vis state', this.clickMap);
               this.$emit(
                 'updateNetwork',
                 expandSuperNetwork(
@@ -642,10 +654,8 @@ export default Vue.extend({
                   supernode,
                 ),
               );
-              // console.log('click map state: ', this.clickMap);
+              console.log('click map state: ', this.clickMap);
             }
-
-        
           } else {
             this.selectElement(d);
             this.selectNeighborNodes(d.id, d.neighbors);

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -3,6 +3,8 @@ import Vue, { PropType } from 'vue';
 
 import {
   superGraph,
+  processChildNodes,
+  processChildLinks,
   expandSuperNetwork,
   retractSuperNetwork,
 } from '@/lib/aggregation';
@@ -1058,8 +1060,8 @@ export default Vue.extend({
         .attr('width', this.colWidth)
         .on('click', (d: string) => {
           if (this.enableGraffinity) {
-            this.nonAggrNodes = this.processChildNodes(this.network.nodes);
-            this.nonAggrLinks = this.processChildLinks(this.network.links);
+            this.nonAggrNodes = processChildNodes(this.network.nodes);
+            this.nonAggrLinks = processChildLinks(this.network.links);
             this.$emit(
               'updateNetwork',
               superGraph(this.network.nodes, this.network.links, d),
@@ -1439,32 +1441,7 @@ export default Vue.extend({
       this.order = order;
       return order;
     },
-    // function for processing nodes
-    processChildNodes(nodes: Node[]) {
-      const nodeCopy: Node[] = [];
-      // original network components
-      nodes.map((node: Node) => {
-        const newNode = {
-          ...node,
-        };
-        newNode.type = 'node';
-        nodeCopy.push(newNode);
-      });
-      return nodeCopy;
-    },
-    // function for processing links
-    processChildLinks(links: Link[]) {
-      const linkCopy: Link[] = [];
-      // original network components
-      links.map((link: Link) => {
-        const newLink = {
-          ...link,
-        };
-        newLink.type = 'link';
-        linkCopy.push(newLink);
-      });
-      return linkCopy;
-    },
+
 
     getApplicationState(): State {
       return this.provenance.graph().current.state;

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -157,7 +157,7 @@ export default Vue.extend({
         this.matrixNodeLength * this.cellSize +
         this.visMargins.left +
         this.visMargins.right
-      );
+      ) ;
     },
 
     matrixHeight(): number {
@@ -262,6 +262,8 @@ export default Vue.extend({
         document.body.clientHeight;
 
       // Size the svgs
+      console.log("matrix node length");
+      console.log(this.network.nodes.length);
       this.matrixSVG = select(this.$refs.matrix)
         .attr('width', this.matrixWidth)
         .attr('height', this.matrixHeight)
@@ -297,8 +299,13 @@ export default Vue.extend({
     },
 
     processData(): void {
+      // console.log("matrix info", this.matrix);
+      this.matrix = [];
       this.network.nodes.forEach((rowNode: Node, i: number) => {
+        console.log("rowNode: ", rowNode.id);
+
         this.matrix[i] = this.network.nodes.map((colNode: Node) => {
+          console.log("colNode: ", colNode.id);
           return {
             cellName: `${rowNode.id}_${colNode.id}`,
             correspondingCell: `${colNode.id}_${rowNode.id}`,
@@ -325,6 +332,8 @@ export default Vue.extend({
           }
         });
       });
+      console.log("the matrix");
+      console.log(this.matrix);
     },
 
     setUpProvenance(): any {
@@ -680,29 +689,29 @@ export default Vue.extend({
             }
             // case when there is at least one expand supernode in the click map
             else if (this.clickMap.size != 0) {
-              console.log('the click map has at least one node expanded');
-              console.log('expand visualization');
-              console.log('network before expansion', this.network);
-              // this.$emit(
-              //   'updateNetwork',
-              //   expandSuperNetwork(
-              //     this.nonAggrNodes,
-              //     this.nonAggrLinks,
-              //     this.superNetwork.nodes,
-              //     this.superNetwork.links,
-              //     superNode,
-              //   ),
-              // );
-              console.log(
-                'expand network',
+              // console.log('the click map has at least one node expanded');
+              // console.log('expand visualization');
+              // console.log('network before expansion', this.network);
+              this.$emit(
+                'updateNetwork',
                 expandSuperNetwork(
                   this.nonAggrNodes,
                   this.nonAggrLinks,
                   this.superNetwork.nodes,
-                  this.network.links,
+                  this.superNetwork.links,
                   superNode,
                 ),
               );
+              // console.log(
+              //   'expand network',
+              //   expandSuperNetwork(
+              //     this.nonAggrNodes,
+              //     this.nonAggrLinks,
+              //     this.superNetwork.nodes,
+              //     this.network.links,
+              //     superNode,
+              //   ),
+              // );
               this.superNetwork = expandSuperNetwork(
                 this.nonAggrNodes,
                 this.nonAggrLinks,
@@ -716,41 +725,41 @@ export default Vue.extend({
             // if the selected node is not in the map
             // add it to the map and visualize the expansion
             else {
-              // console.log("new selection");
-              console.log('the click map has no nodes expanded');
-              this.clickMap.set(d.id, true);
-              console.log('expand the visualization');
-              console.log('agg network before expansion', this.network);
-              this.superNetwork = expandSuperNetwork(
-                this.nonAggrNodes,
-                this.nonAggrLinks,
-                this.network.nodes,
-                this.network.links,
-                superNode,
-              );
-              console.log(
-                'the super network after expansion: ',
-                this.superNetwork,
-              );
-              console.log(
-                'expanded network',
-                expandSuperNetwork(
-                  this.nonAggrNodes,
-                  this.nonAggrLinks,
-                  this.network.nodes,
-                  this.network.links,
-                  superNode,
-                ),
-              );
-              // this.$emit(
-              //   'updateNetwork',
+              // // console.log("new selection");
+              // console.log('the click map has no nodes expanded');
+              // this.clickMap.set(d.id, true);
+              // console.log('expand the visualization');
+              // console.log('agg network before expansion', this.network);
+              // this.superNetwork = expandSuperNetwork(
+              //   this.nonAggrNodes,
+              //   this.nonAggrLinks,
+              //   this.network.nodes,
+              //   this.network.links,
+              //   superNode,
+              // );
+              // console.log(
+              //   'the super network after expansion: ',
+              //   this.superNetwork,
+              // );
+              // console.log(
+              //   'expanded network',
               //   expandSuperNetwork(
               //     this.nonAggrNodes,
               //     this.nonAggrLinks,
               //     this.network.nodes,
               //     this.network.links,
               //     superNode,
-              //   ),);
+              //   ),
+              // );
+              this.$emit(
+                'updateNetwork',
+                expandSuperNetwork(
+                  this.nonAggrNodes,
+                  this.nonAggrLinks,
+                  this.network.nodes,
+                  this.network.links,
+                  superNode,
+                ),);
               console.log('click map state: ', this.clickMap);
             }
           } else {

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -77,7 +77,6 @@ export default Vue.extend({
     provenance: any;
     sortKey: string;
     colMargin: number;
-    attributeScales: { [key: string]: any };
     nonAggrNodes: any;
     nonAggrLinks: any;
     clickMap: any; // variable for keeping track of whether a label has been clicked or not
@@ -108,6 +107,11 @@ export default Vue.extend({
       edgeColumns: undefined,
       edgeRows: undefined,
       cells: undefined,
+      clickMap: undefined,
+      nonAggrNodes: undefined,
+      nonAggrLinks: undefined,
+      expandRetractAggrVisNodes: undefined,
+      expandRetractAggrVisLinks: undefined,
       icons: {
         quant: {
           d:

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -563,31 +563,31 @@ export default Vue.extend({
             }
             const supernode = d;
             // expand and retract the supernode aggregation based on user selection
-              if (this.clickMap.get(supernode.id)) {
-                this.$emit(
-                  'updateNetwork',
-                  retractSuperNetwork(
-                    this.nonAggrNodes,
-                    this.nonAggrLinks,
-                    this.network.nodes,
-                    this.network.links,
-                    supernode,
-                  ),
-                );
-                this.clickMap.set(supernode.id, false);
-              } else {
-                this.$emit(
-                  'updateNetwork',
-                  expandSuperNetwork(
-                    this.nonAggrNodes,
-                    this.nonAggrLinks,
-                    this.network.nodes,
-                    this.network.links,
-                    supernode,
-                  ),
-                );
-                this.clickMap.set(supernode.id, true);
-              }
+            if (this.clickMap.get(supernode.id)) {
+              this.$emit(
+                'updateNetwork',
+                retractSuperNetwork(
+                  this.nonAggrNodes,
+                  this.nonAggrLinks,
+                  this.network.nodes,
+                  this.network.links,
+                  supernode,
+                ),
+              );
+              this.clickMap.set(supernode.id, false);
+            } else {
+              this.$emit(
+                'updateNetwork',
+                expandSuperNetwork(
+                  this.nonAggrNodes,
+                  this.nonAggrLinks,
+                  this.network.nodes,
+                  this.network.links,
+                  supernode,
+                ),
+              );
+              this.clickMap.set(supernode.id, true);
+            }
           } else {
             this.selectElement(d);
             this.selectNeighborNodes(d.id, d.neighbors);
@@ -745,141 +745,6 @@ export default Vue.extend({
       } else {
         state.selections[interaction][nodeID] = [interactionName];
       }
-    },
-
-    appendEdgeLabels(): void {
-      const labelContainerHeight = 25;
-      const rowLabelContainerStart = 75;
-      const labelContainerWidth = rowLabelContainerStart;
-
-      // add foreign objects for label
-      const edgeRowForeignObject = this.edgeRows
-        .append('foreignObject')
-        .attr('x', -rowLabelContainerStart)
-        .attr('y', -5)
-        .attr('width', labelContainerWidth)
-        .attr('height', labelContainerHeight);
-
-      edgeRowForeignObject
-        .append('xhtml:p')
-        .text((d: Node) => d._key)
-        .classed('rowLabels', true)
-        .on('mouseout', (d: Node) => {
-          this.hideToolTip();
-          this.unHoverNode(d.id);
-        })
-        .on('click', (d: Node) => {
-          // allow expanding the vis if graffinity features are on
-          if (this.enableGraffinity) {
-            // if user selects a child node don't do anything
-            if (d.type === 'node') {
-              return;
-            }
-            const supernode = d;
-            // expand and retract the supernode aggregation based on user selection
-            if (this.clickMap.has(supernode.id)) {
-              if (this.clickMap.get(supernode.id) === true) {
-                this.$emit(
-                  'updateNetwork',
-                  retractSuperNetwork(
-                    this.nonAggrNodes,
-                    this.nonAggrLinks,
-                    this.network.nodes,
-                    this.network.links,
-                    supernode,
-                  ),
-                );
-                this.clickMap.set(supernode.id, false);
-              } else {
-                this.$emit(
-                  'updateNetwork',
-                  expandSuperNetwork(
-                    this.nonAggrNodes,
-                    this.nonAggrLinks,
-                    this.network.nodes,
-                    this.network.links,
-                    supernode,
-                  ),
-                );
-                this.clickMap.set(supernode.id, true);
-              }
-            } else {
-              this.$emit(
-                'updateNetwork',
-                expandSuperNetwork(
-                  this.nonAggrNodes,
-                  this.nonAggrLinks,
-                  this.network.nodes,
-                  this.network.links,
-                  supernode,
-                ),
-              );
-              this.clickMap.set(supernode.id, true);
-            }
-          } else {
-            this.selectElement(d);
-            this.selectNeighborNodes(d.id, d.neighbors);
-          }
-        });
-
-      let verticalOffset = 187.5;
-      const horizontalOffset =
-        (this.orderingScale.bandwidth() / 2 - 4.5) / 0.075;
-      this.edgeColumns
-        .append('path')
-        .attr('id', (d: Node) => `sortIcon${d.id}`)
-        .attr('class', 'sortIcon')
-        .attr('d', this.icons.cellSort.d)
-        .style('fill', (d: Node) =>
-          d === this.orderType ? '#EBB769' : '#8B8B8B',
-        )
-        .attr(
-          'transform',
-          `scale(0.075)translate(${verticalOffset},${horizontalOffset})rotate(90)`,
-        )
-        .on('click', (d: Node) => {
-          this.sort(d.id);
-          const action = this.changeInteractionWrapper('neighborSelect');
-          this.provenance.applyAction(action);
-        })
-        .attr('cursor', 'pointer')
-        .on('mouseover', (d: Node, i: number, nodes: any) => {
-          this.showToolTip(d, i, nodes);
-          this.hoverNode(d.id);
-        })
-        .on('mouseout', (d: Node) => {
-          this.hideToolTip();
-          this.unHoverNode(d.id);
-        });
-
-      verticalOffset = verticalOffset * 0.075 + 5;
-
-      // constant for starting the column label container
-      const columnLabelContainerStart = 20;
-
-      const edgeColumnForeignObject = this.edgeColumns
-        .append('foreignObject')
-        .attr('y', -5)
-        .attr('x', columnLabelContainerStart)
-        .attr('width', labelContainerWidth)
-        .attr('height', labelContainerHeight);
-
-      edgeColumnForeignObject
-        .append('xhtml:p')
-        .text((d: Node) => d._key)
-        .classed('colLabels', true)
-        .on('click', (d: Node) => {
-          this.selectElement(d);
-          this.selectNeighborNodes(d.id, d.neighbors);
-        })
-        .on('mouseover', (d: Node, i: number, nodes: any) => {
-          this.showToolTip(d, i, nodes);
-          this.hoverNode(d.id);
-        })
-        .on('mouseout', (d: Node) => {
-          this.hideToolTip();
-          this.unHoverNode(d.id);
-        });
     },
 
     drawGridLines(): void {
@@ -1441,7 +1306,6 @@ export default Vue.extend({
       this.order = order;
       return order;
     },
-
 
     getApplicationState(): State {
       return this.provenance.graph().current.state;

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -556,7 +556,7 @@ export default Vue.extend({
             const supernode = d;
             // expand and retract the supernode aggregation based on user selection
             if (this.clickMap.has(supernode.id)) {
-              if (this.clickMap.get(supernode.id) === true) {
+              if (this.clickMap.get(supernode.id)) {
                 this.$emit(
                   'updateNetwork',
                   retractSuperNetwork(

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -417,7 +417,7 @@ function retractSuperLinksData(
   let newLinks = expandedLinksCopy;
   superChildren.forEach((childNode) => {
     newLinks = newLinks.filter(
-      (link: Link) => link.source !== childNode && link._from !== childNode,
+      (link: Link) => link._from !== childNode,
     );
   });
 

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -316,8 +316,8 @@ export function expandSuperNetwork(
     links: expandLinks,
   };
 
-  // console.log("the final network");
-  // console.log(network);
+  console.log("the final expanded network");
+  console.log(network);
   return network;
 }
 

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -316,8 +316,8 @@ export function expandSuperNetwork(
     links: expandLinks,
   };
 
-  console.log("the final expanded network");
-  console.log(network);
+  // console.log('the final expanded network');
+  // console.log(network);
   return network;
 }
 
@@ -340,7 +340,7 @@ function retractSuperNodeData(
         childNodes.push(childNode);
       }
     });
-    console.log('expanded nodes', expandNodesCopy);
+    // console.log('expanded nodes', expandNodesCopy);
     const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
     const superIndexStart = expandNodesCopy.findIndex(superIndexFunc);
     expandNodesCopy.splice(superIndexStart + 1, childNodes.length);
@@ -393,7 +393,7 @@ function retractSuperLinksData(
     );
   });
 
-  console.log('final links: ', newLinks);
+  // console.log('final links: ', newLinks);
   return newLinks;
 
   // const superIndexFunc = (superNode: ) => superNode.id == superNodeName;
@@ -456,7 +456,7 @@ export function retractSuperNetwork(
     links: retractLinks,
   };
 
-  console.log('the final retracted network');
-  console.log(network);
+  // console.log('the final retracted network');
+  // console.log(network);
   return network;
 }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -6,8 +6,7 @@ import { Link, Node } from '@/types';
 export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
   // Construct new node objects with type property for aggregation
   // and an empty list of neighbors that will be recomputed
-  const newNodes: Node[] = 
-  nodes.map((node) => {
+  const newNodes: Node[] = nodes.map((node) => {
     const newNode = {
       ...node,
     };
@@ -50,13 +49,12 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
   });
 
   // Construct new link objects with type property for aggregation
-  const newLinks: Link[] = [];
-  edges.forEach((link) => {
+  const newLinks: Link[] = edges.map((link) => {
     const newLink = {
       ...link,
     };
     newLink.type = 'superLink';
-    newLinks.push(newLink);
+    return newLink;
   });
 
   // Update _from, _to, target, and source properties for visualizing network

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -146,6 +146,36 @@ function mapNetworkNodes(nodes: Node[]) {
   return nodeMap;
 }
 
+// Function that processes the non-aggregated network nodes
+// and assigns a type to the node
+    export function processChildNodes(nodes: Node[]) {
+      const nodeCopy: Node[] = [];
+      // original network components
+      nodes.map((node: Node) => {
+        const newNode = {
+          ...node,
+        };
+        newNode.type = 'node';
+        nodeCopy.push(newNode);
+      });
+      return nodeCopy;
+    }
+
+// Function that processes the non-aggregated network links
+// and assigns a type to the link
+    export function processChildLinks(links: Link[]) {
+      const linkCopy: Link[] = [];
+      // original network components
+      links.map((link: Link) => {
+        const newLink = {
+          ...link,
+        };
+        newLink.type = 'link';
+        linkCopy.push(newLink);
+      });
+      return linkCopy;
+    }
+
 // Function that maps children nodes to supernode (parent) nodes
 function mapSuperChildren(superNodes: Node[]) {
   const superChildrenMap = new Map<string, string>();

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -69,7 +69,6 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
         if (linkFrom === origin) {
           const newLinkFrom = superNode.id;
           link._from = newLinkFrom;
-          link.source = link._from;
         }
         if (linkTo === origin) {
           const newLinkTo = superNode.id;

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -117,6 +117,34 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
   return network;
 }
 
+// functions for deep copying nodes and links
+function deepCopyNodes(nodes: Node[]) {
+  const nodeCopy: Node[] = [];
+  // original network components
+  nodes.map((node: Node) => {
+    const newNode = {
+      ...node,
+    };
+    newNode.neighbors = [];
+    nodeCopy.push(newNode);
+  });
+
+  return nodeCopy;
+}
+
+function deepCopyLinks(links: Link[]) {
+  const linkCopy: Link[] = [];
+  // original network components
+  links.map((link: Link) => {
+    const newLink = {
+      ...link,
+    };
+    linkCopy.push(newLink);
+  });
+  return linkCopy;
+}
+
+
 // this function is for expanding the super network for visualization
 export function expandSuperNetwork(
   nonAggrNodes: Node[],
@@ -124,10 +152,14 @@ export function expandSuperNetwork(
   aggrNodes: Node[],
   aggrLinks: Link[],
 ) {
-  console.log('child nodes: ', nonAggrNodes);
-  console.log('child links: ', nonAggrLinks);
-  console.log('supernodes: ', aggrNodes);
-  console.log('superlinks: ', aggrLinks);
+  const nonAggrNodesCopy = deepCopyNodes(nonAggrNodes);
+  const nonAggrLinksCopy = deepCopyLinks(nonAggrLinks);
+  const aggrNodesCopy = deepCopyNodes(aggrNodes);
+  const aggrLinksCopy = deepCopyLinks(aggrLinks);
+  console.log('child nodes: ', nonAggrNodesCopy);
+  console.log('child links: ', nonAggrLinksCopy);
+  console.log('supernodes: ', aggrNodesCopy);
+  console.log('superlinks: ', aggrLinksCopy);
 }
 
 // this function is for retracting the super network visualization

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -73,7 +73,6 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
         if (linkTo === origin) {
           const newLinkTo = superNode.id;
           link._to = newLinkTo;
-          link.target = link._to;
         }
       });
     });

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -266,7 +266,6 @@ function expandSuperLinksData(
     const parent = superChildrenDict.get(linkTo);
     if (parent !== undefined) {
       link._to = parent;
-      link.target = link._to;
     }
   });
 

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -459,7 +459,7 @@ export function retractSuperNetwork(
 
   // Create a new set of neighbors for the new network nodes
   let neighborNodes: Node[] = [];
-  if (retractNodes && retractLinks !== undefined) {
+  if (retractNodes !== undefined && retractLinks !== undefined) {
     neighborNodes = defineNeighborNodes(retractNodes, retractLinks);
   }
 

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -219,11 +219,6 @@ function expandSuperNodeData(
       count += 1;
     });
 
-    // Update the index of the new nodes the expanded vis network
-    superNodeCopy.forEach((node: Node, index: number) => {
-      node.index = index;
-    });
-
     return superNodeCopy;
   }
 }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -175,9 +175,9 @@ function mapNetworkNodes(nodes: Node[]) {
     }
 
 // Function that maps children nodes to supernode (parent) nodes
-function mapSuperChildren(superNodes: Node[]) {
+function mapSuperChildren(node: Node[]) {
   const superChildrenMap = new Map<string, string>();
-  superNodes.forEach((networkNode: Node) => {
+  node.forEach((networkNode: Node) => {
     if (networkNode.type === 'node') {
       return;
     }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -321,6 +321,35 @@ export function expandSuperNetwork(
   return network;
 }
 
+// this function retracts the supernodes if they are double clicked twice
+function retractSuperNodeData(
+  superNodeName: string,
+  aggrNodesCopy: Node[],
+  childrenNodeNameDict: Map<string, Node>,
+  superNodeNameDict: Map<string, Node>,
+) {
+  const expandNodesCopy = deepCopyNodes(aggrNodesCopy);
+  const superNode = superNodeNameDict.get(superNodeName);
+
+  if (superNode != undefined) {
+    const superChildrenIDs = superNode.CHILDREN;
+    const childNodes: Node[] = [];
+    superChildrenIDs.forEach((id: string) => {
+      const childNode = childrenNodeNameDict.get(id);
+      if (childNode != undefined) {
+        childNodes.push(childNode);
+      }
+    });
+    console.log('expanded nodes', expandNodesCopy);
+    // let count = 0;
+    const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
+    const superIndexStart = expandNodesCopy.findIndex(superIndexFunc);
+    console.log('supernode start index', superIndexStart);
+    expandNodesCopy.splice(superIndexStart + 1, childNodes.length);
+    console.log('nodes after removal', expandNodesCopy);
+  }
+}
+
 // this function is for retracting the super network visualization
 export function retractSuperNetwork(
   nonAggrNodes: Node[],
@@ -347,4 +376,12 @@ export function retractSuperNetwork(
   console.log('children node dict: ', childrenNodeNameDict);
   console.log('supernode name dict: ', superNodeNameDict);
   console.log('super children dict: ', superChildrenDict);
+
+  // calculate a list of new nodes
+  retractSuperNodeData(
+    superNode.id,
+    aggrNodesCopy,
+    childrenNodeNameDict,
+    superNodeNameDict,
+  );
 }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -5,8 +5,6 @@
 import { defineSuperNeighbors } from '@/lib/multinet';
 import { Link, Node } from '@/types';
 
-// function that creates a deep copy of nodes
-// function that creates a deep copy of links
 export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
   // de-construct nodes into their original components and
   // make a new list of nodes
@@ -24,6 +22,7 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
     // add new node to node list
     newNodes.push(newNode);
   });
+
   // create a list that results of the selected attribute from the nodes
   const selectedAttributes = new Set<string>();
 
@@ -246,7 +245,7 @@ function expandSuperLinksData(
   return combinedLinks;
 }
 
-// this function that constructs the neighbors for a node in a super network
+// function that constructs the neighbors for a node in a super network
 function defineNeighborNodes(nodes: Node[], links: Link[]) {
   nodes.map((d: { neighbors: string[] }) => (d.neighbors = []));
   links.forEach((link) => {
@@ -259,7 +258,7 @@ function defineNeighborNodes(nodes: Node[], links: Link[]) {
   });
   return nodes;
 }
-// this function is for expanding the super network for visualization
+//function is for expanding the super network for visualization
 export function expandSuperNetwork(
   nonAggrNodes: Node[],
   nonAggrLinks: Link[],
@@ -306,7 +305,7 @@ export function expandSuperNetwork(
   return network;
 }
 
-// this function retracts the supernodes if they are double clicked twice
+// function retracts the supernodes if they are double clicked twice
 function retractSuperNodeData(
   superNodeName: string,
   aggrNodesCopy: Node[],
@@ -337,7 +336,7 @@ function retractSuperNodeData(
   }
 }
 
-// this function creates a new set of links by removing the
+// function creates a new set of links by removing the
 // links added from the expand superlinks function
 function retractSuperLinksData(
   superNodeName: string,
@@ -345,11 +344,9 @@ function retractSuperLinksData(
   nonAggrLinksCopy: Link[],
   superNodeNameDict: Map<string, Node>,
 ) {
-  // make deep copies of the links
   const childLinksCopy = deepCopyLinks(nonAggrLinksCopy);
   const expandedLinksCopy = deepCopyLinks(expandedLinks);
 
-  // get the node information about the supernode
   const superNode = superNodeNameDict.get(superNodeName);
   let superChildren: string[] = [];
   if (superNode != undefined) {
@@ -377,7 +374,7 @@ function retractSuperLinksData(
   return newLinks;
 }
 
-// this function is for retracting the super network visualization
+// function is for retracting the super network visualization
 export function retractSuperNetwork(
   nonAggrNodes: Node[],
   nonAggrLinks: Link[],

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -202,7 +202,7 @@ function expandSuperNodeData(
 
   // If the supernode exists in the dictionary, 
   // get the children of the supernode
-  if (superNode != undefined) {
+  if (superNode !== undefined) {
     const superChildrenIDs = superNode.CHILDREN;
     const childNodes: Node[] = [];
     superChildrenIDs.forEach((id: string) => {

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -369,11 +369,6 @@ function retractSuperNodeData(
     const superIndexStart = expandNodesCopy.findIndex(superIndexFunc);
     expandNodesCopy.splice(superIndexStart + 1, childNodes.length);
 
-    // Update the index of the new nodes in the retracted vis network
-    expandNodesCopy.forEach((node: Node, index: number) => {
-      node.index = index;
-    });
-
     return expandNodesCopy;
   }
 }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -358,7 +358,7 @@ function retractSuperNodeData(
       }
     });
 
-    // Find and insert the children of the remaining supernodes and their children (if any)
+    // Find and insert => remove the children of the remaining supernodes and their children (if any)
     // in the correct position for visualizing the supergraph network
     const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
     const superIndexStart = expandNodesCopy.findIndex(superIndexFunc);

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -358,8 +358,8 @@ function retractSuperNodeData(
       }
     });
 
-    // Find and insert => remove the children of the remaining supernodes and their children (if any)
-    // in the correct position for visualizing the supergraph network
+    // Find and remove the children of the selected supernode and insert remaining nodes
+    // into the correct position for visualizing the supergraph network
     const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
     const superIndexStart = expandNodesCopy.findIndex(superIndexFunc);
     expandNodesCopy.splice(superIndexStart + 1, childNodes.length);

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -158,7 +158,7 @@ function mapNetworkNodes(nodes: Node[]) {
 function mapSuperChildren(superNodes: Node[]) {
   const superChildrenMap = new Map<string, string>();
   superNodes.forEach((networkNode: Node) => {
-    if (networkNode.type === "node") { 
+    if (networkNode.type === 'node') {
       return;
     }
     const superChildren = networkNode.CHILDREN;
@@ -220,8 +220,8 @@ function expandSuperLinksData(
   if (superNode != undefined) {
     superChildren = superNode.CHILDREN;
   }
-  console.log('the children of the supernode selected');
-  console.log(superChildren);
+  // console.log('the children of the supernode selected');
+  // console.log(superChildren);
 
   // create a list of links whose _from is one of the superchildren selected
   const superChildrenLinks: Link[] = [];
@@ -275,16 +275,16 @@ export function expandSuperNetwork(
   const nonAggrLinksCopy = deepCopyLinks(nonAggrLinks);
   const aggrNodesCopy = deepCopyNodes(aggrNodes);
   const aggrLinksCopy = deepCopyLinks(aggrLinks);
-  console.log('child nodes: ', nonAggrNodesCopy);
-  console.log('child links: ', nonAggrLinksCopy);
+  // console.log('child nodes: ', nonAggrNodesCopy);
+  // console.log('child links: ', nonAggrLinksCopy);
   // console.log('supernodes: ', aggrNodesCopy);
-  console.log('superlinks: ', aggrLinksCopy);
+  // console.log('superlinks: ', aggrLinksCopy);
   // console.log('superNode', superNode);
 
+  // data for expanding the vis
   const childrenNodeNameDict = mapNetworkNodes(nonAggrNodesCopy);
   const superNodeNameDict = mapNetworkNodes(aggrNodesCopy);
   const superChildrenDict = mapSuperChildren(aggrNodesCopy);
-  console.log('superchildren dict', superChildrenDict);
 
   // calculate a new list of supernodes
   const expandNodes = expandSuperNodeData(
@@ -293,7 +293,7 @@ export function expandSuperNetwork(
     childrenNodeNameDict,
     superNodeNameDict,
   );
-  console.log('the expanded nodes', expandNodes);
+  // console.log('the expanded nodes', expandNodes);
 
   // calculate a new set of links
   const expandLinks = expandSuperLinksData(
@@ -303,7 +303,7 @@ export function expandSuperNetwork(
     superNodeNameDict,
     superChildrenDict,
   );
-  console.log('the expanded links', expandLinks);
+  // console.log('the expanded links', expandLinks);
 
   let neighborNodes: Node[] = [];
   if (expandNodes && expandLinks != undefined) {
@@ -327,9 +327,24 @@ export function retractSuperNetwork(
   nonAggrLinks: Link[],
   aggrNodes: Node[],
   aggrLinks: Link[],
+  superNode: Node,
 ) {
-  console.log('child nodes: ', nonAggrNodes);
-  console.log('child links: ', nonAggrLinks);
-  console.log('supernodes: ', aggrNodes);
-  console.log('superlinks: ', aggrLinks);
+  const nonAggrNodesCopy = deepCopyNodes(nonAggrNodes);
+  const nonAggrLinksCopy = deepCopyLinks(nonAggrLinks);
+  const aggrNodesCopy = deepCopyNodes(aggrNodes);
+  const aggrLinksCopy = deepCopyLinks(aggrLinks);
+  // console.log('child nodes: ', nonAggrNodesCopy);
+  console.log('child links: ', nonAggrLinksCopy);
+  // console.log('supernodes: ', aggrNodesCopy);
+  console.log('superlinks: ', aggrLinksCopy);
+  console.log('superNode', superNode);
+
+  // data for retracting the vis
+  const childrenNodeNameDict = mapNetworkNodes(nonAggrNodesCopy);
+  const superNodeNameDict = mapNetworkNodes(aggrNodesCopy);
+  const superChildrenDict = mapSuperChildren(aggrNodesCopy);
+
+  console.log('children node dict: ', childrenNodeNameDict);
+  console.log('supernode name dict: ', superNodeNameDict);
+  console.log('super children dict: ', superChildrenDict);
 }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -331,7 +331,7 @@ export function expandSuperNetwork(
 
   // Create a new set of neighbors for the new network nodes
   let neighborNodes: Node[] = [];
-  if (expandNodes && expandLinks != undefined) {
+  if (expandNodes !== undefined && expandLinks !== undefined) {
     neighborNodes = defineNeighborNodes(expandNodes, expandLinks);
   }
 

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -346,7 +346,13 @@ function retractSuperNodeData(
     const superIndexStart = expandNodesCopy.findIndex(superIndexFunc);
     console.log('supernode start index', superIndexStart);
     expandNodesCopy.splice(superIndexStart + 1, childNodes.length);
+
+    // update the index of the new supernodes
+    expandNodesCopy.forEach((node: Node, index: number) => {
+      node.index = index;
+    });
     console.log('nodes after removal', expandNodesCopy);
+    return expandNodesCopy;
   }
 }
 

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -371,7 +371,7 @@ function retractSuperLinksData(
   if (superNode != undefined) {
     superChildren = superNode.CHILDREN;
   }
-  console.log('the children of the supernode selected', superChildren);
+  // console.log('the children of the supernode selected', superChildren);
   // create a list of links whose _from is one of the superchildren selected
   const superChildrenLinks: Link[] = [];
 
@@ -384,10 +384,10 @@ function retractSuperLinksData(
     });
   });
 
-  console.log('subset of the original links', superChildrenLinks);
+  // console.log('subset of the original links', superChildrenLinks);
   let newLinks = expandedLinksCopy;
   superChildren.forEach((childNode) => {
-    console.log('child node', childNode);
+    // console.log('child node', childNode);
     newLinks = newLinks.filter(
       (link: Link) => link.source !== childNode && link._from !== childNode,
     );
@@ -442,8 +442,8 @@ export function retractSuperNetwork(
     superNodeNameDict,
   );
 
-  console.log('nodes after removal', retractNodes);
-  console.log('links after removal', retractLinks);
+  // console.log('nodes after removal', retractNodes);
+  // console.log('links after removal', retractLinks);
 
   let neighborNodes: Node[] = [];
   if (retractNodes && retractLinks != undefined) {

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -220,9 +220,7 @@ function expandSuperLinksData(
   if (superNode != undefined) {
     superChildren = superNode.CHILDREN;
   }
-  // console.log('the children of the supernode selected');
-  // console.log(superChildren);
-
+  
   // create a list of links whose _from is one of the superchildren selected
   const superChildrenLinks: Link[] = [];
 
@@ -245,8 +243,6 @@ function expandSuperLinksData(
     }
   });
   const combinedLinks = superLinksCopy.concat(superChildrenLinks);
-
-  // console.log('the final combined links: ', combinedLinks);
   return combinedLinks;
 }
 
@@ -275,11 +271,6 @@ export function expandSuperNetwork(
   const nonAggrLinksCopy = deepCopyLinks(nonAggrLinks);
   const aggrNodesCopy = deepCopyNodes(aggrNodes);
   const aggrLinksCopy = deepCopyLinks(aggrLinks);
-  // console.log('child nodes: ', nonAggrNodesCopy);
-  // console.log('child links: ', nonAggrLinksCopy);
-  // console.log('supernodes: ', aggrNodesCopy);
-  // console.log('superlinks: ', aggrLinksCopy);
-  // console.log('superNode', superNode);
 
   // data for expanding the vis
   const childrenNodeNameDict = mapNetworkNodes(nonAggrNodesCopy);
@@ -293,7 +284,6 @@ export function expandSuperNetwork(
     childrenNodeNameDict,
     superNodeNameDict,
   );
-  // console.log('the expanded nodes', expandNodes);
 
   // calculate a new set of links
   const expandLinks = expandSuperLinksData(
@@ -303,8 +293,6 @@ export function expandSuperNetwork(
     superNodeNameDict,
     superChildrenDict,
   );
-  // console.log('the expanded links', expandLinks);
-
   let neighborNodes: Node[] = [];
   if (expandNodes && expandLinks != undefined) {
     neighborNodes = defineNeighborNodes(expandNodes, expandLinks);
@@ -315,9 +303,6 @@ export function expandSuperNetwork(
     nodes: neighborNodes,
     links: expandLinks,
   };
-
-  // console.log('the final expanded network');
-  // console.log(network);
   return network;
 }
 
@@ -340,7 +325,6 @@ function retractSuperNodeData(
         childNodes.push(childNode);
       }
     });
-    // console.log('expanded nodes', expandNodesCopy);
     const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
     const superIndexStart = expandNodesCopy.findIndex(superIndexFunc);
     expandNodesCopy.splice(superIndexStart + 1, childNodes.length);
@@ -371,11 +355,11 @@ function retractSuperLinksData(
   if (superNode != undefined) {
     superChildren = superNode.CHILDREN;
   }
-  // console.log('the children of the supernode selected', superChildren);
+
   // create a list of links whose _from is one of the superchildren selected
   const superChildrenLinks: Link[] = [];
 
-  // get the subset of the links whose from id matches the chidlren nodes
+  // get the subset of the links whose from id matches the children nodes
   childLinksCopy.forEach((link: Link) => {
     superChildren.forEach((childNodeName: string) => {
       if (link._from === childNodeName) {
@@ -384,20 +368,13 @@ function retractSuperLinksData(
     });
   });
 
-  // console.log('subset of the original links', superChildrenLinks);
   let newLinks = expandedLinksCopy;
   superChildren.forEach((childNode) => {
-    // console.log('child node', childNode);
     newLinks = newLinks.filter(
       (link: Link) => link.source !== childNode && link._from !== childNode,
     );
   });
-
-  // console.log('final links: ', newLinks);
   return newLinks;
-
-  // const superIndexFunc = (superNode: ) => superNode.id == superNodeName;
-  // const superIndexStart = superChildrenLinks.findIndex(superIndexFunc);
 }
 
 // this function is for retracting the super network visualization
@@ -412,19 +389,10 @@ export function retractSuperNetwork(
   const nonAggrLinksCopy = deepCopyLinks(nonAggrLinks);
   const aggrNodesCopy = deepCopyNodes(aggrNodes);
   const aggrLinksCopy = deepCopyLinks(aggrLinks);
-  // console.log('child nodes: ', nonAggrNodesCopy);
-  // console.log('child links: ', nonAggrLinksCopy);
-  // console.log('supernodes: ', aggrNodesCopy);
-  // console.log('superlinks: ', aggrLinksCopy);
-  // console.log('superNode', superNode);
 
   // data for retracting the vis
   const childrenNodeNameDict = mapNetworkNodes(nonAggrNodesCopy);
   const superNodeNameDict = mapNetworkNodes(aggrNodesCopy);
-
-  // console.log('children node dict: ', childrenNodeNameDict);
-  // console.log('supernode name dict: ', superNodeNameDict);
-  // console.log('super children dict: ', superChildrenDict);
 
   // calculate a list of new nodes
   const retractNodes = retractSuperNodeData(
@@ -442,9 +410,6 @@ export function retractSuperNetwork(
     superNodeNameDict,
   );
 
-  // console.log('nodes after removal', retractNodes);
-  // console.log('links after removal', retractLinks);
-
   let neighborNodes: Node[] = [];
   if (retractNodes && retractLinks != undefined) {
     neighborNodes = defineNeighborNodes(retractNodes, retractLinks);
@@ -455,8 +420,5 @@ export function retractSuperNetwork(
     nodes: neighborNodes,
     links: retractLinks,
   };
-
-  // console.log('the final retracted network');
-  // console.log(network);
   return network;
 }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -282,7 +282,7 @@ function defineNeighborNodes(nodes: Node[], links: Link[]) {
   links.forEach((link) => {
     const findNodeFrom = nodes.find((node) => node.id === link._from);
     const findNodeTo = nodes.find((node) => node.id === link._to);
-    if (findNodeFrom && findNodeTo !== undefined) {
+    if (findNodeFrom !== undefined && findNodeTo !== undefined) {
       findNodeFrom.neighbors.push(link._to);
       findNodeTo.neighbors.push(link._from);
     }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -6,14 +6,14 @@ import { Link, Node } from '@/types';
 export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
   // Construct new node objects with type property for aggregation
   // and an empty list of neighbors that will be recomputed
-  const newNodes: Node[] = [];
+  const newNodes: Node[] = 
   nodes.map((node) => {
     const newNode = {
       ...node,
     };
     newNode.neighbors = [];
     newNode.type = 'node';
-    newNodes.push(newNode);
+    return newNode;
   });
 
   // Set for keeping track of attribute selected by user

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -1,7 +1,7 @@
 import { defineSuperNeighbors } from '@/lib/multinet';
 import { Link, Node } from '@/types';
 
-// Function that builds a supergraph network that contains 
+// Function that builds a supergraph network that contains
 // supernodes, superlinks, nodes, and links
 export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
   // Construct new node objects with type property for aggregation
@@ -22,7 +22,7 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
     selectedAttributes.add(node[attribute]);
   });
 
-  // Data structure for ensuring constant time lookup between 
+  // Data structure for ensuring constant time lookup between
   // selected attribute and supernodes
   const superMap = new Map<string, Node>();
 
@@ -146,33 +146,33 @@ function mapNetworkNodes(nodes: Node[]) {
 
 // Function that processes the non-aggregated network nodes
 // and assigns a type to the node
-    export function processChildNodes(nodes: Node[]) {
-      const nodeCopy: Node[] = [];
-      // original network components
-      nodes.map((node: Node) => {
-        const newNode = {
-          ...node,
-        };
-        newNode.type = 'node';
-        nodeCopy.push(newNode);
-      });
-      return nodeCopy;
-    }
+export function processChildNodes(nodes: Node[]) {
+  const nodeCopy: Node[] = [];
+  // original network components
+  nodes.map((node: Node) => {
+    const newNode = {
+      ...node,
+    };
+    newNode.type = 'node';
+    nodeCopy.push(newNode);
+  });
+  return nodeCopy;
+}
 
 // Function that processes the non-aggregated network links
 // and assigns a type to the link
-    export function processChildLinks(links: Link[]) {
-      const linkCopy: Link[] = [];
-      // original network components
-      links.map((link: Link) => {
-        const newLink = {
-          ...link,
-        };
-        newLink.type = 'link';
-        linkCopy.push(newLink);
-      });
-      return linkCopy;
-    }
+export function processChildLinks(links: Link[]) {
+  const linkCopy: Link[] = [];
+  // original network components
+  links.map((link: Link) => {
+    const newLink = {
+      ...link,
+    };
+    newLink.type = 'link';
+    linkCopy.push(newLink);
+  });
+  return linkCopy;
+}
 
 // Function that maps children nodes to supernode (parent) nodes
 function mapSuperChildren(node: Node[]) {
@@ -200,7 +200,7 @@ function expandSuperNodeData(
   const superNodeCopy = deepCopyNodes(aggrNodesCopy);
   const superNode = superNodeNameDict.get(superNodeName);
 
-  // If the supernode exists in the dictionary, 
+  // If the supernode exists in the dictionary,
   // get the children of the supernode
   if (superNode !== undefined) {
     const superChildrenIDs = superNode.CHILDREN;
@@ -259,7 +259,7 @@ function expandSuperLinksData(
     });
   });
 
-  // Update the superchildren link subset to map connections between nodes and supernodes 
+  // Update the superchildren link subset to map connections between nodes and supernodes
   // in the new expanded vis network
   superChildrenLinks.forEach((link) => {
     const linkTo = link._to;
@@ -415,9 +415,7 @@ function retractSuperLinksData(
   // links associated with the children of the supernode selected
   let newLinks = expandedLinksCopy;
   superChildren.forEach((childNode) => {
-    newLinks = newLinks.filter(
-      (link: Link) => link._from !== childNode,
-    );
+    newLinks = newLinks.filter((link: Link) => link._from !== childNode);
   });
 
   return newLinks;

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -144,6 +144,27 @@ function deepCopyLinks(links: Link[]) {
   return linkCopy;
 }
 
+// function that maps node names to node objects
+// <name, Node>
+function MapNetworkNodes(nodes: Node[]) {
+  const nodeMap = new Map<string, Node>();
+  nodes.forEach((node: Node) => {
+    nodeMap.set(node.id, node);
+  });
+  return nodeMap;
+}
+
+// function that maps all supernode children to their parent supernode
+function mapSuperChildren(superNodes: Node[]) {
+  const superChildrenMap = new Map<string, string>();
+  superNodes.forEach((parentNode: Node) => {
+    const superChildren = parentNode.CHILDREN;
+    superChildren.forEach((childNode: string) => {
+      superChildrenMap.set(childNode, parentNode.id);
+    });
+  });
+  return superChildrenMap;
+}
 
 // this function is for expanding the super network for visualization
 export function expandSuperNetwork(
@@ -151,6 +172,7 @@ export function expandSuperNetwork(
   nonAggrLinks: Link[],
   aggrNodes: Node[],
   aggrLinks: Link[],
+  superNode: Node,
 ) {
   const nonAggrNodesCopy = deepCopyNodes(nonAggrNodes);
   const nonAggrLinksCopy = deepCopyLinks(nonAggrLinks);
@@ -160,6 +182,21 @@ export function expandSuperNetwork(
   console.log('child links: ', nonAggrLinksCopy);
   console.log('supernodes: ', aggrNodesCopy);
   console.log('superlinks: ', aggrLinksCopy);
+  console.log('superNode', superNode);
+
+  const childrenNodeNameDict = MapNetworkNodes(nonAggrNodesCopy);
+  const superChildrenDict = mapSuperChildren(aggrNodesCopy);
+
+  console.log('children map', childrenNodeNameDict);
+  console.log('superchildren map', superChildrenDict);
+
+  //   // calculate a new list of supernodes
+  // const expandNodes = expandSuperDataNodes(
+  //   superNode.id,
+  //   superNetwork,
+  //   childrenNodeNameDict,
+  //   superNodeNameDict,
+  // );
 }
 
 // this function is for retracting the super network visualization

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -45,7 +45,7 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
   newNodes.forEach((node: Node) => {
     if (selectedAttributes.has(node[attribute])) {
       const superNode = superMap.get(node[attribute]);
-      if (superNode != undefined) superNode.CHILDREN.push(node.id);
+      if (superNode !== undefined) superNode.CHILDREN.push(node.id);
     }
   });
 
@@ -91,7 +91,7 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
     finalNodes.forEach((node) => {
       if (children.includes(node.id)) {
         const nodeIDValue = node.id;
-        finalNodes = finalNodes.filter((node) => node.id != nodeIDValue);
+        finalNodes = finalNodes.filter((node) => node.id !== nodeIDValue);
       }
     });
   });
@@ -207,7 +207,7 @@ function expandSuperNodeData(
     const childNodes: Node[] = [];
     superChildrenIDs.forEach((id: string) => {
       const childNode = childrenNodeNameDict.get(id);
-      if (childNode != undefined) {
+      if (childNode !== undefined) {
         childNodes.push(childNode);
       }
     });
@@ -245,7 +245,7 @@ function expandSuperLinksData(
   // Construct a list of the children nodes that belong to the selected supernode
   const superNode = superNodeNameDict.get(superNodeName);
   let superChildren: string[] = [];
-  if (superNode != undefined) {
+  if (superNode !== undefined) {
     superChildren = superNode.CHILDREN;
   }
 
@@ -264,7 +264,7 @@ function expandSuperLinksData(
   superChildrenLinks.forEach((link) => {
     const linkTo = link._to;
     const parent = superChildrenDict.get(linkTo);
-    if (parent != undefined) {
+    if (parent !== undefined) {
       link._to = parent;
       link.target = link._to;
     }
@@ -283,7 +283,7 @@ function defineNeighborNodes(nodes: Node[], links: Link[]) {
   links.forEach((link) => {
     const findNodeFrom = nodes.find((node) => node.id === link._from);
     const findNodeTo = nodes.find((node) => node.id === link._to);
-    if (findNodeFrom && findNodeTo != undefined) {
+    if (findNodeFrom && findNodeTo !== undefined) {
       findNodeFrom.neighbors.push(link._to);
       findNodeTo.neighbors.push(link._from);
     }
@@ -356,12 +356,12 @@ function retractSuperNodeData(
 
   // If the supernode exists in the dictionary,
   // get the children of the supernode
-  if (superNode != undefined) {
+  if (superNode !== undefined) {
     const superChildrenIDs = superNode.CHILDREN;
     const childNodes: Node[] = [];
     superChildrenIDs.forEach((id: string) => {
       const childNode = childrenNodeNameDict.get(id);
-      if (childNode != undefined) {
+      if (childNode !== undefined) {
         childNodes.push(childNode);
       }
     });
@@ -395,7 +395,7 @@ function retractSuperLinksData(
   // Construct a list of the children nodes that belong to the selected supernode
   const superNode = superNodeNameDict.get(superNodeName);
   let superChildren: string[] = [];
-  if (superNode != undefined) {
+  if (superNode !== undefined) {
     superChildren = superNode.CHILDREN;
   }
 
@@ -462,7 +462,7 @@ export function retractSuperNetwork(
 
   // Create a new set of neighbors for the new network nodes
   let neighborNodes: Node[] = [];
-  if (retractNodes && retractLinks != undefined) {
+  if (retractNodes && retractLinks !== undefined) {
     neighborNodes = defineNeighborNodes(retractNodes, retractLinks);
   }
 


### PR DESCRIPTION
Closes #124
Close #132 
Closes #115 
PR for restructuring the expand supernodes so that the matrix will not re-render every time the user clicks on a chevron

Demo Video
https://user-images.githubusercontent.com/24800816/104494774-bf1b8900-558b-11eb-9075-1715f0471540.mp4

