### PR TITLE
Add toggle to enable edge directionality

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -24,6 +24,7 @@ export default Vue.extend({
     selectNeighbors: boolean;
     showGridLines: boolean;
     enableGraffinity: boolean;
+    directional: boolean;
     visualizedAttributes: string[];
   } {
     return {
@@ -36,6 +37,7 @@ export default Vue.extend({
       selectNeighbors: true,
       showGridLines: true,
       enableGraffinity: false,
+      directional: false,
       visualizedAttributes: [],
     };
   },
@@ -180,6 +182,14 @@ export default Vue.extend({
             <v-list-item-content> Show GridLines </v-list-item-content>
           </v-list-item>
 
+          <!-- Directional Edges Toggle Card -->
+          <v-list-item class="px-0">
+            <v-list-item-action class="mr-3">
+              <v-switch class="ma-0" v-model="directional" hide-details />
+            </v-list-item-action>
+            <v-list-item-content> Directional Edges </v-list-item-content>
+          </v-list-item>
+
           <!-- Graffinity Toggle List Item -->
           <v-list-item class="px-0">
             <v-list-item-action class="mr-3">
@@ -232,6 +242,7 @@ export default Vue.extend({
             showGridLines,
             enableGraffinity,
             visualizedAttributes,
+            directional,
           }"
           @restart-simulation="hello()"
           @updateMatrixLegendScale="createLegend"

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -42,6 +42,10 @@ export default Vue.extend({
       type: Array as PropType<string[]>,
       default: () => [],
     },
+    directional: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data(): {
@@ -171,7 +175,14 @@ export default Vue.extend({
     properties() {
       this.updateVis();
     },
+
     network() {
+      this.generateIdMap();
+      this.processData();
+      this.changeMatrix();
+    },
+
+    directional() {
       this.generateIdMap();
       this.processData();
       this.changeMatrix();
@@ -291,7 +302,10 @@ export default Vue.extend({
       // Count occurrences of links and store it in the matrix
       this.network.links.forEach((link: Link) => {
         this.matrix[this.idMap[link.source]][this.idMap[link.target]].z += 1;
-        this.matrix[this.idMap[link.target]][this.idMap[link.source]].z += 1;
+
+        if (!this.directional) {
+          this.matrix[this.idMap[link.target]][this.idMap[link.source]].z += 1;
+        }
       });
 
       // Find max value of z


### PR DESCRIPTION
Closes #145 

Prior to this PR, edges were being counted in both directions. This is fine when that information is not directional (like a relationship in the les mis dataset), but when the edges encode a specific directional relationship we want to see that. This PR addresses that issue.

I added a toggle for edge directionality and updated the code to only count in one direction if directional edges is on. This code required a bit of duplicated logic for watching the `directional` prop and updating the matrix. Once we have a better strategy for handling updates to props (enter, exit, merge, etc.) we can refactor this so that we don't need to tear the matrix down and rebuild it.