### PR TITLE
Make idMap a computed property, instead of a data prop

### DIFF
--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -54,7 +54,6 @@ export default Vue.extend({
     matrixSVG: any;
     attributesSVG: any;
     cellSize: number;
-    idMap: { [key: string]: number };
     maxNumConnections: number;
     matrix: Cell[][];
     attributes: any;
@@ -83,7 +82,6 @@ export default Vue.extend({
       matrixSVG: undefined,
       attributesSVG: undefined,
       cellSize: 15,
-      idMap: {},
       maxNumConnections: -Infinity,
       matrix: [],
       attributes: undefined,
@@ -169,6 +167,16 @@ export default Vue.extend({
     matrixHighlightLength(): number {
       return this.matrix.length * this.cellSize;
     },
+
+    idMap() {
+      const computedIdMap: { [key: string]: number } = {};
+      this.network.nodes.forEach((node: Node, index: number) => {
+        node.index = index;
+        computedIdMap[node.id] = index;
+      });
+
+      return computedIdMap;
+    },
   },
 
   watch: {
@@ -177,13 +185,11 @@ export default Vue.extend({
     },
 
     network() {
-      this.generateIdMap();
       this.processData();
       this.changeMatrix();
     },
 
     directional() {
-      this.generateIdMap();
       this.processData();
       this.changeMatrix();
     },
@@ -210,8 +216,6 @@ export default Vue.extend({
       .attr('width', this.attributesWidth)
       .attr('height', this.attributesHeight)
       .attr('viewBox', `0 0 ${this.attributesWidth} ${this.attributesHeight}`);
-
-    this.generateIdMap();
 
     // Run process data to convert links to cells
     this.processData();
@@ -274,14 +278,6 @@ export default Vue.extend({
 
       this.initializeAttributes();
       this.initializeEdges();
-    },
-
-    generateIdMap() {
-      this.idMap = {};
-      this.network.nodes.forEach((node: Node, index: number) => {
-        node.index = index;
-        this.idMap[node.id] = index;
-      });
     },
 
     processData(): void {

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -171,7 +171,6 @@ export default Vue.extend({
     idMap() {
       const computedIdMap: { [key: string]: number } = {};
       this.network.nodes.forEach((node: Node, index: number) => {
-        node.index = index;
         computedIdMap[node.id] = index;
       });
 
@@ -282,14 +281,14 @@ export default Vue.extend({
 
     processData(): void {
       this.network.nodes.forEach((rowNode: Node, i: number) => {
-        this.matrix[i] = this.network.nodes.map((colNode: Node) => {
+        this.matrix[i] = this.network.nodes.map((colNode: Node, j: number) => {
           return {
             cellName: `${rowNode.id}_${colNode.id}`,
             correspondingCell: `${colNode.id}_${rowNode.id}`,
             rowID: rowNode.id,
             colID: colNode.id,
-            x: colNode.index,
-            y: rowNode.index,
+            x: j,
+            y: i,
             z: 0,
           };
         });


### PR DESCRIPTION
Depends on #160 (That uses the generateIdMap function, so I figured it would be easier to remove it in this follow up)

Closes #143 

I altered the logic for generating the idMap, by turning it into a computed prop. The idMap is generated from this.network so when the network changes, so does the idMap. 

I saw room for a secondary improvement, which was removing the `index` property from the nodes, since that is calculated in the idMap step and is superflous. The index of the nodes in this.network will not change after this.idMap is generated, which it is every time the network updates.