### PR TITLE
Prefer _from and _to to source and target

### DIFF
--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -301,10 +301,10 @@ export default Vue.extend({
 
       // Count occurrences of links and store it in the matrix
       this.network.links.forEach((link: Link) => {
-        this.matrix[this.idMap[link.source]][this.idMap[link.target]].z += 1;
+        this.matrix[this.idMap[link._from]][this.idMap[link._to]].z += 1;
 
         if (!this.directional) {
-          this.matrix[this.idMap[link.target]][this.idMap[link.source]].z += 1;
+          this.matrix[this.idMap[link._to]][this.idMap[link._from]].z += 1;
         }
       });
 
@@ -1175,13 +1175,14 @@ export default Vue.extend({
       ) {
         const links: any[] = Array(this.network.links.length);
 
+        // Generate links that are compatible with reorder.js
         this.network.links.forEach((link: Link, index: number) => {
           links[index] = {
             source: this.network.nodes.find(
-              (node: Node) => node.id === link.source,
+              (node: Node) => node.id === link._from,
             ),
             target: this.network.nodes.find(
-              (node: Node) => node.id === link.target,
+              (node: Node) => node.id === link._to,
             ),
           };
         });

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -74,12 +74,10 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
         if (linkFrom === origin) {
           const newLinkFrom = superNode.id;
           link._from = newLinkFrom;
-          link.source = link._from;
         }
         if (linkTo === origin) {
           const newLinkTo = superNode.id;
           link._to = newLinkTo;
-          link.target = link._to;
         }
       });
     });

--- a/src/lib/multinet.ts
+++ b/src/lib/multinet.ts
@@ -39,8 +39,6 @@ async function _downloadAllRows(
 function _renameLinkVars(links: any[]): Link[] {
   links.forEach((link) => {
     link.id = link._id;
-    link.source = link._from;
-    link.target = link._to;
     delete link._id;
   });
   return links;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,8 @@ export interface Dimensions {
 export interface Link {
   _key: string;
   id: string;
-  source: string;
-  target: string;
+  _from: string;
+  _to: string;
   [propName: string]: any;
 }
 


### PR DESCRIPTION
Depends on #160 (Since the logic for calculating the cell fill is based on source & target)

Closes #144 

I removed all references to source and target from the app, instead preferring to use _from and _to. This simplifies the logic in data pulling and in aggregation, and keeps it about the same elsewhere. There is one spot that required source and target, the sorting using reorder.js, so there is a spot where source and target are generated as they are needed. The logic to do that already existed, though.