### PR TITLE
Add D3 enter, exit, merge to allow the network to be changed in place while triggering a re-render of the matrix

### DIFF
--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -623,6 +623,7 @@ export default Vue.extend({
     },
 
     drawGridLines(): void {
+      selectAll('.gridLines').remove();
       const gridLines = this.edges.append('g').attr('class', 'gridLines');
 
       const lines = gridLines.selectAll('line').data(this.matrix).enter();

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -226,6 +226,46 @@ export default Vue.extend({
         `translate(${this.visMargins.left},${this.visMargins.top})`,
       );
 
+    // Draw buttons for alternative sorts
+    let initialY = -this.visMargins.left + 10;
+    const buttonHeight = 15;
+    const text = ['name', 'cluster', 'interacts'];
+    const sortNames = ['shortName', 'clusterLeaf', 'edges'];
+    const iconNames = ['alphabetical', 'categorical', 'quant'];
+    for (let i = 0; i < 3; i++) {
+      const button = this.edges
+        .append('g')
+        .attr('transform', `translate(${-this.visMargins.left},${initialY})`);
+      button.attr('cursor', 'pointer');
+      button
+        .append('rect')
+        .attr('width', this.visMargins.left - 5)
+        .attr('height', buttonHeight)
+        .attr('fill', 'none')
+        .attr('stroke', 'gray')
+        .attr('stroke-width', 1);
+      button
+        .append('text')
+        .attr('x', 27)
+        .attr('y', 10)
+        .attr('font-size', 11)
+        .text(text[i]);
+      const path = button.datum(sortNames[i]);
+      path
+        .append('path')
+        .attr('class', 'sortIcon')
+        .attr('d', (d: any, i: number) => {
+          return this.icons[iconNames[i]].d;
+        })
+        .style('fill', () =>
+          sortNames[i] === this.orderType ? '#EBB769' : '#8B8B8B',
+        )
+        .attr('transform', 'scale(0.1)translate(-195,-320)')
+        .attr('cursor', 'pointer');
+      button.on('click', () => this.sort(sortNames[i]));
+      initialY += buttonHeight + 5;
+    }
+
     this.provenance = this.setUpProvenance();
 
     this.initializeAttributes();
@@ -403,46 +443,6 @@ export default Vue.extend({
         .attr('cursor', 'pointer');
 
       this.appendEdgeLabels();
-
-      // Draw buttons for alternative sorts
-      let initialY = -this.visMargins.left + 10;
-      const buttonHeight = 15;
-      const text = ['name', 'cluster', 'interacts'];
-      const sortNames = ['shortName', 'clusterLeaf', 'edges'];
-      const iconNames = ['alphabetical', 'categorical', 'quant'];
-      for (let i = 0; i < 3; i++) {
-        const button = this.edges
-          .append('g')
-          .attr('transform', `translate(${-this.visMargins.left},${initialY})`);
-        button.attr('cursor', 'pointer');
-        button
-          .append('rect')
-          .attr('width', this.visMargins.left - 5)
-          .attr('height', buttonHeight)
-          .attr('fill', 'none')
-          .attr('stroke', 'gray')
-          .attr('stroke-width', 1);
-        button
-          .append('text')
-          .attr('x', 27)
-          .attr('y', 10)
-          .attr('font-size', 11)
-          .text(text[i]);
-        const path = button.datum(sortNames[i]);
-        path
-          .append('path')
-          .attr('class', 'sortIcon')
-          .attr('d', (d: any, i: number) => {
-            return this.icons[iconNames[i]].d;
-          })
-          .style('fill', () =>
-            sortNames[i] === this.orderType ? '#EBB769' : '#8B8B8B',
-          )
-          .attr('transform', 'scale(0.1)translate(-195,-320)')
-          .attr('cursor', 'pointer');
-        button.on('click', () => this.sort(sortNames[i]));
-        initialY += buttonHeight + 5;
-      }
     },
 
     changeInteractionWrapper(interactionType: string, cell?: Cell): any {

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -505,9 +505,10 @@ export default Vue.extend({
         .domain([0, this.maxNumConnections])
         .range(['#feebe2', '#690000']); // TODO: colors here are arbitrary, change later
 
-      this.edgeRows
+      // Draw cells
+      selectAll('.cellsGroup')
         .selectAll('.cell')
-        .data((d: Node, i: number) => this.matrix[i])
+        .data((d: unknown, i: number) => this.matrix[i])
         .enter()
         .append('rect')
         .attr('class', 'cell')

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -366,7 +366,7 @@ export default Vue.extend({
       // creates column groupings
       this.edgeColumns = this.edges
         .selectAll('.column')
-        .data(this.network.nodes);
+        .data(this.network.nodes, (d: Node) => d._id || d.id);
 
       this.edgeColumns.exit().remove();
 
@@ -446,7 +446,7 @@ export default Vue.extend({
       // Draw each row
       this.edgeRows = this.edges
         .selectAll('.rowContainer')
-        .data(this.network.nodes, (d) => d.matrix);
+        .data(this.network.nodes, (d: Node) => d._id || d.id);
 
       this.edgeRows.exit().remove();
 

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -285,6 +285,7 @@ export default Vue.extend({
     },
 
     processData(): void {
+      this.matrix = [];
       this.network.nodes.forEach((rowNode: Node, i: number) => {
         this.matrix[i] = this.network.nodes.map((colNode: Node, j: number) => {
           return {

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -516,7 +516,7 @@ export default Vue.extend({
         .attr('id', (d: Cell) => d.cellName)
         .attr('x', (d: Cell) => {
           const xLocation = this.orderingScale(d.x);
-          return xLocation !== undefined ? xLocation + 1 : undefined;
+          return xLocation !== undefined ? xLocation + 1 : null;
         })
         .attr('y', 1)
         .attr('width', this.cellSize - 2)

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -353,6 +353,16 @@ export default Vue.extend({
       // set the matrix highlight
       const matrixHighlightLength = this.matrix.length * this.cellSize;
 
+      // constant for starting the column label container
+      const columnLabelContainerStart = 20;
+      const labelContainerHeight = 25;
+      const rowLabelContainerStart = 75;
+      const labelContainerWidth = rowLabelContainerStart;
+
+      const verticalOffset = 187.5;
+      const horizontalOffset =
+        (this.orderingScale.bandwidth() / 2 - 4.5) / 0.075;
+
       // creates column groupings
       this.edgeColumns = this.edges
         .selectAll('.column')

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -240,41 +240,6 @@ export default Vue.extend({
     },
 
     changeMatrix(this: any) {
-      select('#matrix').selectAll('*').remove();
-
-      this.browser.width =
-        window.innerWidth ||
-        document.documentElement.clientWidth ||
-        document.body.clientWidth;
-
-      this.browser.height =
-        window.innerHeight ||
-        document.documentElement.clientHeight ||
-        document.body.clientHeight;
-
-      // Size the svgs
-      this.matrixSVG = select(this.$refs.matrix)
-        .attr('width', this.matrixWidth)
-        .attr('height', this.matrixHeight)
-        .attr('viewBox', `0 0 ${this.matrixWidth} ${this.matrixHeight}`);
-
-      this.attributesSVG = select(this.$refs.attributes)
-        .attr('width', this.attributesWidth)
-        .attr('height', this.attributesHeight)
-        .attr(
-          'viewBox',
-          `0 0 ${this.attributesWidth} ${this.attributesHeight}`,
-        );
-
-      this.edges = select('#matrix')
-        .append('g')
-        .attr(
-          'transform',
-          `translate(${this.visMargins.left},${this.visMargins.top})`,
-        );
-
-      this.provenance = this.setUpProvenance();
-
       this.initializeAttributes();
       this.initializeEdges();
     },


### PR DESCRIPTION
Might address #150 (will need to be tested with a network that will add and remove nodes in place)
Closes #148 

Adds D3 style enter, exit, merge to the rendering function and stops the matrix from being fully removed during each re-render. I also moved some of the icon rendering logic since that doesn't need to be re-rendered on each network update.

Open questions:
- Where should we move the gridlines to? I can see a place for them inside the matrix rows and in the vue rendering. We could also remove them
- Should I try move some of the rendering to the vue layer or do we need D3 for transitions etc.?
- I think I used an old syntax, would it be worth trying to update it to use D3v5 joins instead?

TODO (these can likely just become issues for follow ups):
- [x] Fix lingering bugs with data binding
- [ ] Verify that the computed values for the cells are correct
- [ ] Update attributes when the network updates
- [x] Fix grid line rendering (maybe this is a spot for vue?)
- [x] Sorting is still broken from before (Fixed by resetting the this.matrix variable)
- [ ] Legend seems to get out of sync/doesn't update