### PR TITLE
Fix color scale legend calculation and legend reactivity

### DIFF
--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -196,6 +196,10 @@ export default Vue.extend({
       this.processData();
       this.changeMatrix();
     },
+
+    colorScale() {
+      this.$emit('updateMatrixLegendScale', this.colorScale);
+    },
   },
 
   async mounted(this: any) {
@@ -274,8 +278,6 @@ export default Vue.extend({
 
     this.initializeAttributes();
     this.initializeEdges();
-
-    this.$emit('updateMatrixLegendScale', this.colorScale);
   },
 
   methods: {

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -62,7 +62,6 @@ export default Vue.extend({
     edges: any;
     edgeColumns: any;
     edgeRows: any;
-    colorScale: ScaleLinear<string, number>;
     icons: { [key: string]: { [d: string]: string } };
     selectedNodesAndNeighbors: { [key: string]: string[] };
     selectedElements: { [key: string]: string[] };
@@ -90,7 +89,6 @@ export default Vue.extend({
       edges: undefined,
       edgeColumns: undefined,
       edgeRows: undefined,
-      colorScale: scaleLinear<string, number>(),
       icons: {
         quant: {
           d:
@@ -175,6 +173,12 @@ export default Vue.extend({
       });
 
       return computedIdMap;
+    },
+
+    colorScale(): ScaleLinear<string, number> {
+      return scaleLinear<string, number>()
+        .domain([0, this.maxNumConnections])
+        .range(['#feebe2', '#690000']); // TODO: colors here are arbitrary, change later
     },
   },
 
@@ -501,10 +505,6 @@ export default Vue.extend({
       this.edgeRows.merge(rowEnter);
 
       this.drawGridLines();
-
-      this.colorScale
-        .domain([0, this.maxNumConnections])
-        .range(['#feebe2', '#690000']); // TODO: colors here are arbitrary, change later
 
       // Draw cells
       selectAll('.cellsGroup')

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -291,7 +291,10 @@ export default Vue.extend({
     },
 
     processData(): void {
+      // Reset some values that will be re-calcuated
+      this.maxNumConnections = 0;
       this.matrix = [];
+
       this.network.nodes.forEach((rowNode: Node, i: number) => {
         this.matrix[i] = this.network.nodes.map((colNode: Node, j: number) => {
           return {


### PR DESCRIPTION
Closes #170

There were a couple issue that needed to be fixed in this PR:

1. The color scale could never reduce its max value, since the max value was never reset
2. Updates to the colorScale didn't automatically trigger an emit, it was a separate event. Using a watcher for this would solve the problem.
3. The code was a little dispersed and could be condensed into a computed prop

I fixed the 3 issues above using the solutions that I mentioned, resetting the max value, using a watcher instead of manually emitting changes to the color scale, and making the colorScale a computed prop.