### PR TITLE
Make the attribute vis reactive to changes

### DIFF
--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -745,50 +745,31 @@ export default Vue.extend({
       // Just has to be larger than the attributes panel (so that we render to the edge)
       const attributeWidth = 1000;
 
-      this.attributes = select('#attributes')
-        .append('g')
-        .attr('transform', `translate(0,${this.visMargins.top})`);
+      // Add/Update zebras
+      this.attributeZebras = (select('.zebras') as any)
+        .selectAll('.attrRowBackground')
+        .data(this.network.nodes, (d: Node) => d._id || d.id);
 
-      // add zebras and highlight rows
-      this.attributes
-        .selectAll('.highlightRow')
-        .data(this.network.nodes)
-        .enter()
+      this.attributeZebras.exit().remove();
+
+      const attributeZebrasEnter = this.attributeZebras.enter().append('g').attr('class', 'attrRowBackground');
+
+      attributeZebrasEnter
         .append('rect')
-        .classed('highlightRow', true)
-        .attr('x', 0)
+        .classed('zebra', true)
         .attr('y', (d: Node, i: number) => this.orderingScale(i))
         .attr('width', attributeWidth)
         .attr('height', this.orderingScale.bandwidth())
         .attr('fill', (d: Node, i: number) => (i % 2 === 0 ? '#fff' : '#eee'));
 
-      // Draw each row (translating the y coordinate)
-      this.attributeRows = this.attributes
-        .selectAll('.attrRowContainer')
-        .data(this.network.nodes)
-        .enter()
-        .append('g')
-        .attr('class', 'attrRowContainer')
-        .attr(
-          'transform',
-          (d: Node, i: number) => `translate(0,${this.orderingScale(i)})`,
-        );
-
-      this.attributeRows
-        .append('line')
-        .attr('x1', 0)
-        .attr('x2', attributeWidth)
-        .attr('stroke', '2px')
-        .attr('stroke-opacity', 0.3);
-
-      this.attributeRows
+      // Highlightable backgrounds for the vis
+      attributeZebrasEnter
         .append('rect')
-        .attr('x', 0)
-        .attr('y', 0)
-        .classed('attrRow', true)
-        .attr('id', (d: Node) => `attrRow${d.id}`)
+        .classed('highlightRow', true)
+        .attr('y', (d: Node, i: number) => this.orderingScale(i))
+        .attr('id', (d: Node) => `highlightRow${d.id}`)
         .attr('width', attributeWidth)
-        .attr('height', this.orderingScale.bandwidth()) // end addition
+        .attr('height', this.orderingScale.bandwidth())
         .attr('fill-opacity', 0)
         .attr('cursor', 'pointer')
         .on('mouseover', (d: Node, i: number, nodes: any) => {
@@ -798,12 +779,13 @@ export default Vue.extend({
         .on('mouseout', (d: Node) => {
           this.hideToolTip();
           this.unHoverNode(d.id);
+        })
+        .on('click', (d: Node) => {
+          this.selectElement(d);
+          this.selectNeighborNodes(d.id, d.neighbors);
         });
-      // .on('click', (d: Node) => {
-      //   this.selectElement(d);
-      //   this.selectNeighborNodes(d.id, d.neighbors);
-      // });
 
+      this.attributeZebras.merge(attributeZebrasEnter);
       this.columnHeaders = this.attributes
         .append('g')
         .classed('column-headers', true);

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -207,7 +207,7 @@ export default Vue.extend({
 
   watch: {
     properties() {
-      this.updateVis();
+      this.renderAttributes();
     },
 
     network() {
@@ -295,7 +295,7 @@ export default Vue.extend({
 
     this.provenance = this.setUpProvenance();
 
-    this.initializeAttributes();
+    this.renderAttributes();
     this.initializeEdges();
 
     this.$emit('updateMatrixLegendScale', this.colorScale);
@@ -307,7 +307,7 @@ export default Vue.extend({
     },
 
     changeMatrix(this: any) {
-      this.initializeAttributes();
+      this.renderAttributes();
       this.initializeEdges();
     },
 
@@ -741,7 +741,7 @@ export default Vue.extend({
         .style('fill', '#EBB769');
     },
 
-    initializeAttributes(): void {
+    renderAttributes(): void {
       // Just has to be larger than the attributes panel (so that we render to the edge)
       const attributeWidth = 1000;
 

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -302,10 +302,6 @@ export default Vue.extend({
   },
 
   methods: {
-    updateVis() {
-      this.updateAttributes();
-    },
-
     changeMatrix(this: any) {
       this.renderAttributes();
       this.initializeEdges();
@@ -789,9 +785,7 @@ export default Vue.extend({
       this.columnHeaders = this.attributes
         .append('g')
         .classed('column-headers', true);
-    },
 
-    updateAttributes(): void {
       // Set the column widths and margin
       const attrWidth = parseFloat(select('#attributes').attr('width'));
       const colWidth =

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -863,16 +863,6 @@ export default Vue.extend({
       selectAll('.attr-axis').remove();
 
       // Add the scale bar at the top of the attr column
-      attributeRowsEnter
-        .append('g')
-        .attr('class', 'attr-axis')
-        .attr(
-          'transform',
-          (d: string, i: number) =>
-            `translate(${(this.colWidth + this.colMargin) * i},-15)`,
-        );
-
-      // Add the scale bar at the top of the attr column
       this.visualizedAttributes.forEach((col: string, index: number) => {
         if (this.isQuantitative(col)) {
           this.attributes

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -58,6 +58,7 @@ export default Vue.extend({
     matrix: Cell[][];
     attributes: any;
     attributeRows: any;
+    attributeZebras: any;
     columnHeaders: any;
     edges: any;
     edgeColumns: any;
@@ -85,6 +86,7 @@ export default Vue.extend({
       matrix: [],
       attributes: undefined,
       attributeRows: undefined,
+      attributeZebras: undefined,
       columnHeaders: undefined,
       edges: undefined,
       edgeColumns: undefined,
@@ -612,7 +614,7 @@ export default Vue.extend({
 
             // interactID = cellData.rowID;
             // interactionName = interactionName + 'row'
-          } else if (interactionName === 'attrRow') {
+          } else if (interactionName === 'highlightRow') {
             return interactionName;
           } else if (interactionName === 'neighborSelect') {
             this.changeInteraction(
@@ -946,13 +948,13 @@ export default Vue.extend({
         } else {
           // Get all the elements to be selected
           elementsToSelect = [
-            `[id="attrRow${element.colID}"]`,
+            `[id="highlightRow${element.colID}"]`,
             `[id="topoRow${element.colID}"]`,
             `[id="topoCol${element.colID}"]`,
             `[id="colLabel${element.colID}"]`,
             `[id="rowLabel${element.colID}"]`,
 
-            `[id="attrRow${element.rowID}"]`,
+            `[id="highlightRow${element.rowID}"]`,
             `[id="topoRow${element.rowID}"]`,
             `[id="topoCol${element.rowID}"]`,
             `[id="colLabel${element.rowID}"]`,
@@ -971,7 +973,7 @@ export default Vue.extend({
           delete this.selectedElements[element.id];
         } else {
           elementsToSelect = [
-            `[id="attrRow${element.id}"]`,
+            `[id="highlightRow${element.id}"]`,
             `[id="topoRow${element.id}"]`,
             `[id="topoCol${element.id}"]`,
             `[id="colLabel${element.id}"]`,
@@ -1020,7 +1022,7 @@ export default Vue.extend({
       const selections: string[] = [];
       for (const node of Object.keys(this.selectedNodesAndNeighbors)) {
         for (const neighborNode of this.selectedNodesAndNeighbors[node]) {
-          selections.push(`[id="attrRow${neighborNode}"]`);
+          selections.push(`[id="highlightRow${neighborNode}"]`);
           selections.push(`[id="topoRow${neighborNode}"]`);
           selections.push(`[id="nodeLabelRow${neighborNode}"]`);
         }
@@ -1198,12 +1200,12 @@ export default Vue.extend({
     },
 
     hoverNode(nodeID: string): void {
-      const cssSelector = `[id="attrRow${nodeID}"],[id="topoRow${nodeID}"],[id="topoCol${nodeID}"]`;
+      const cssSelector = `[id="highlightRow${nodeID}"],[id="topoRow${nodeID}"],[id="topoCol${nodeID}"]`;
       selectAll(cssSelector).classed('hovered', true);
     },
 
     unHoverNode(nodeID: string): void {
-      const cssSelector = `[id="attrRow${nodeID}"],[id="topoRow${nodeID}"],[id="topoCol${nodeID}"]`;
+      const cssSelector = `[id="highlightRow${nodeID}"],[id="topoRow${nodeID}"],[id="topoCol${nodeID}"]`;
       selectAll(cssSelector).classed('hovered', false);
     },
 

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -253,6 +253,12 @@ export default Vue.extend({
         `translate(${this.visMargins.left},${this.visMargins.top})`,
       );
 
+    this.attributes = select('#attributes')
+      .append('g')
+      .attr('transform', `translate(0,${this.visMargins.top})`);
+
+    this.attributes.append('g').attr('class', 'zebras');
+
     // Draw buttons for alternative sorts
     let initialY = -this.visMargins.left + 10;
     const buttonHeight = 15;

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -755,7 +755,10 @@ export default Vue.extend({
 
       this.attributeZebras.exit().remove();
 
-      const attributeZebrasEnter = this.attributeZebras.enter().append('g').attr('class', 'attrRowBackground');
+      const attributeZebrasEnter = this.attributeZebras
+        .enter()
+        .append('g')
+        .attr('class', 'attrRowBackground');
 
       attributeZebrasEnter
         .append('rect')


### PR DESCRIPTION
This doesn't address a specific issue, but does seem to fix #168 as a by-product

I copied the same formula from the reactivity of the cells for this and made the attributes reactive. I changed the logic slightly so now it's not done by row, it's instead done as columns, one for each variable, which helps reduce complexity when defining width, x, etc. The zebras and highlights are now much better, too, and they react as you'd expect

Appologies in advance for the large commit 24ed92b, it's a bit of a monster since it was hard to break out the code moving from the logic changes.