### PR TITLE
Make the cells reactive to updates from prop

### DIFF
--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -62,6 +62,7 @@ export default Vue.extend({
     edges: any;
     edgeColumns: any;
     edgeRows: any;
+    cells: any;
     icons: { [key: string]: { [d: string]: string } };
     selectedNodesAndNeighbors: { [key: string]: string[] };
     selectedElements: { [key: string]: string[] };
@@ -89,6 +90,7 @@ export default Vue.extend({
       edges: undefined,
       edgeColumns: undefined,
       edgeRows: undefined,
+      cells: undefined,
       icons: {
         quant: {
           d:
@@ -501,9 +503,12 @@ export default Vue.extend({
       this.drawGridLines();
 
       // Draw cells
-      selectAll('.cellsGroup')
+      this.cells = selectAll('.cellsGroup')
         .selectAll('.cell')
-        .data((d: unknown, i: number) => this.matrix[i])
+        .data((d: unknown, i: number) => this.matrix[i]);
+
+      // Render new cells
+      const cellsEnter = this.cells
         .enter()
         .append('rect')
         .attr('class', 'cell')
@@ -528,6 +533,8 @@ export default Vue.extend({
         })
         .on('click', (d: Cell) => this.selectElement(d))
         .attr('cursor', 'pointer');
+
+      this.cells.merge(cellsEnter);
     },
 
     changeInteractionWrapper(interactionType: string, cell?: Cell): any {

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -507,6 +507,32 @@ export default Vue.extend({
         .selectAll('.cell')
         .data((d: unknown, i: number) => this.matrix[i]);
 
+      // Update existing cells
+      this.cells
+        .attr('id', (d: Cell) => d.cellName)
+        .attr('x', (d: Cell) => {
+          const xLocation = this.orderingScale(d.x);
+          return xLocation !== undefined ? xLocation + 1 : null;
+        })
+        .attr('y', 1)
+        .attr('width', this.cellSize - 2)
+        .attr('height', this.cellSize - 2)
+        .attr('rx', cellRadius)
+        .style('fill', (d: Cell) => this.colorScale(d.z))
+        .style('fill-opacity', (d: Cell) => d.z)
+        .on('mouseover', (d: Cell, i: number, nodes: any) => {
+          this.showToolTip(d, i, nodes);
+          this.hoverEdge(d);
+        })
+        .on('mouseout', (d: Cell) => {
+          this.hideToolTip();
+          this.unHoverEdge(d);
+        })
+        .on('click', (d: Cell) => this.selectElement(d))
+        .attr('cursor', 'pointer');
+
+      this.cells.exit().remove();
+
       // Render new cells
       const cellsEnter = this.cells
         .enter()


### PR DESCRIPTION
Closes #171

The code that renders the cells was not able to update existing DOM elements with new fill and with new position (e.g. @mozartfish updates). This fix solves that problem by defining the fill and position on the new elements. To do that, I need to add a component level data variable to track the cells (this.cells) and then call the updates on that.