### PR TITLE
Animating Rows - Fixes Issue #181

### DIFF
--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -430,12 +430,12 @@ export default Vue.extend({
           return `translate(${this.orderingScale(i)})rotate(-90)`;
         });
 
-      // this.edgeColumns.exit().remove();
-      this.edgeColumns.exit()
-      .transition()
-      .duration(1000)
-      .style('opacity', 0.2)
-      .remove();
+      this.edgeColumns
+        .exit()
+        .transition()
+        .duration(1000)
+        .style('opacity', 0.2)
+        .remove();
 
       const columnEnter = this.edgeColumns
         .enter()
@@ -518,11 +518,7 @@ export default Vue.extend({
           return `translate(0,${this.orderingScale(i)})`;
         });
 
-      // this.edgeRows.exit().remove();
       this.edgeRows.exit()
-      .transition()
-      .duration(1000)
-      .style('opacity', 0.2)
       .remove()
 
       const rowEnter = this.edgeRows
@@ -613,7 +609,11 @@ export default Vue.extend({
       // Draw cells
       this.cells = selectAll('.cellsGroup')
         .selectAll('.cell')
-        .data((d: unknown, i: number) => this.matrix[i]);
+        .data((d: unknown, i: number) => {
+          console.log(i, this.matrix[i]);
+          return this.matrix[i];
+        });
+      // .data((d: unknown, i: number) => this.matrix[i]);
 
       // Update existing cells
       this.cells

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -442,7 +442,7 @@ export default Vue.extend({
               d.parentPosition,
             )})rotate(-90)`;
           } else {
-            return `translate(0, 0)`;
+            return `translate(0, 0)rotate(-90)`;
           }
         });
 

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -430,12 +430,7 @@ export default Vue.extend({
           return `translate(${this.orderingScale(i)})rotate(-90)`;
         });
 
-      this.edgeColumns
-        .exit()
-        .transition()
-        .duration(500)
-        .style('opacity', 0.2)
-        .remove();
+      this.edgeColumns.exit().remove()
 
       const columnEnter = this.edgeColumns
         .enter()

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -518,7 +518,12 @@ export default Vue.extend({
           return `translate(0,${this.orderingScale(i)})`;
         });
 
-      this.edgeRows.exit().remove();
+      // this.edgeRows.exit().remove();
+      this.edgeRows.exit()
+      .transition()
+      .duration(1000)
+      .style('opacity', 0.2)
+      .remove()
 
       const rowEnter = this.edgeRows
         .enter()

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -430,12 +430,25 @@ export default Vue.extend({
           return `translate(${this.orderingScale(i)})rotate(-90)`;
         });
 
-      this.edgeColumns.exit().remove()
+      this.edgeColumns.exit().remove();
 
       const columnEnter = this.edgeColumns
         .enter()
         .append('g')
         .attr('class', 'column')
+        .attr('transform', (d: Node) => {
+          if (d.type === 'node') {
+            return `translate(${this.orderingScale(
+              d.parentPosition,
+            )})rotate(-90)`;
+          } else {
+            return `translate(0, 0)`;
+          }
+        });
+
+      columnEnter
+        .transition()
+        .duration(1000)
         .attr('transform', (d: Node, i: number) => {
           return `translate(${this.orderingScale(i)})rotate(-90)`;
         });

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -430,7 +430,12 @@ export default Vue.extend({
           return `translate(${this.orderingScale(i)})rotate(-90)`;
         });
 
-      this.edgeColumns.exit().remove();
+      // this.edgeColumns.exit().remove();
+      this.edgeColumns.exit()
+      .transition()
+      .duration(1000)
+      .style('opacity', 0.2)
+      .remove();
 
       const columnEnter = this.edgeColumns
         .enter()

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -433,7 +433,7 @@ export default Vue.extend({
       this.edgeColumns
         .exit()
         .transition()
-        .duration(1000)
+        .duration(500)
         .style('opacity', 0.2)
         .remove();
 
@@ -518,18 +518,23 @@ export default Vue.extend({
           return `translate(0,${this.orderingScale(i)})`;
         });
 
-      this.edgeRows.exit()
-      .remove()
+      this.edgeRows.exit().remove();
 
       const rowEnter = this.edgeRows
         .enter()
         .append('g')
         .attr('class', 'rowContainer')
-        .attr('transform', `translate(0, 0)`);
+        .attr('transform', (d: Node) => {
+          if (d.type === 'node') {
+            return `translate(0, ${this.orderingScale(d.parentPosition)})`;
+          } else {
+            return `translate(0, 0)`;
+          }
+        });
 
       rowEnter
         .transition()
-        .duration(1100)
+        .duration(1000)
         .attr('transform', (d: Node, i: number) => {
           return `translate(0,${this.orderingScale(i)})`;
         });
@@ -609,11 +614,7 @@ export default Vue.extend({
       // Draw cells
       this.cells = selectAll('.cellsGroup')
         .selectAll('.cell')
-        .data((d: unknown, i: number) => {
-          console.log(i, this.matrix[i]);
-          return this.matrix[i];
-        });
-      // .data((d: unknown, i: number) => this.matrix[i]);
+        .data((d: unknown, i: number) => this.matrix[i]);
 
       // Update existing cells
       this.cells

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -379,11 +379,7 @@ function retractSuperNodeData(
     const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
     const superIndexStart = expandNodesCopy.findIndex(superIndexFunc);
     expandNodesCopy.splice(superIndexStart + 1, childNodes.length);
-    // Update the index of the new nodes in the retracted vis network
-    expandNodesCopy.forEach((node: Node, index: number) => {
-      node.index = index;
-    });
-
+    
     return expandNodesCopy;
   }
 }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -44,7 +44,7 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
   newNodes.forEach((node: Node) => {
     if (selectedAttributes.has(node[attribute])) {
       const superNode = superMap.get(node[attribute]);
-      if (superNode !== undefined) { 
+      if (superNode !== undefined) {
         superNode.CHILDREN.push(node.id);
       }
     }
@@ -101,7 +101,7 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
     nodes: finalNodes,
     links: newLinks,
   };
-
+  
   return network;
 }
 
@@ -196,6 +196,7 @@ function expandSuperNodeData(
   aggrNodesCopy: Node[],
   childrenNodeNameDict: Map<string, Node>,
   superNodeNameDict: Map<string, Node>,
+  superChildrenMap: Map<string, string>,
 ) {
   const nodeCopy = deepCopyNodes(aggrNodesCopy);
   const superNode = superNodeNameDict.get(superNodeName);
@@ -225,6 +226,23 @@ function expandSuperNodeData(
     nodeCopy.forEach((node: Node, index: number) => {
       node.index = index;
     });
+
+    // Add a parent position value for the regular nodes
+    nodeCopy.forEach((node: Node) => {
+      if (node.type === 'node') {
+        // look up the child Node's parent if it has one
+        const parentNodeID = superChildrenMap.get(node.id);
+        if (parentNodeID) {
+          // get the parent node in the list
+          const parentIndexFunc = (matrixNode: Node) =>
+            matrixNode.id === parentNodeID;
+          const parentNodePosition = nodeCopy.findIndex(parentIndexFunc);
+          node.parentPosition = parentNodePosition;
+        }
+      }
+    });
+
+    console.log(nodeCopy);
     return nodeCopy;
   }
 }
@@ -316,6 +334,7 @@ export function expandSuperNetwork(
     aggrNodesCopy,
     childrenNodeNameDict,
     superNodeNameDict,
+    superChildrenDict,
   );
 
   // Construct a new set of network links

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -379,7 +379,7 @@ function retractSuperNodeData(
     const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
     const superIndexStart = expandNodesCopy.findIndex(superIndexFunc);
     expandNodesCopy.splice(superIndexStart + 1, childNodes.length);
-    
+
     return expandNodesCopy;
   }
 }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -44,7 +44,9 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
   newNodes.forEach((node: Node) => {
     if (selectedAttributes.has(node[attribute])) {
       const superNode = superMap.get(node[attribute]);
-      if (superNode !== undefined) superNode.CHILDREN.push(node.id);
+      if (superNode !== undefined) { 
+        superNode.CHILDREN.push(node.id);
+      }
     }
   });
 
@@ -195,7 +197,7 @@ function expandSuperNodeData(
   childrenNodeNameDict: Map<string, Node>,
   superNodeNameDict: Map<string, Node>,
 ) {
-  const superNodeCopy = deepCopyNodes(aggrNodesCopy);
+  const nodeCopy = deepCopyNodes(aggrNodesCopy);
   const superNode = superNodeNameDict.get(superNodeName);
 
   // If the supernode exists in the dictionary,
@@ -211,15 +213,19 @@ function expandSuperNodeData(
     });
 
     // Find and insert the children of the selected supernode into the correct spot
-    const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
-    const superIndexStart = superNodeCopy.findIndex(superIndexFunc);
+    const insertNodeFunc = (superNode: Node) => superNode.id == superNodeName;
+    const insertNodeStart = nodeCopy.findIndex(insertNodeFunc);
     let count = 1;
     childNodes.forEach((node) => {
-      superNodeCopy.splice(superIndexStart + count, 0, node);
+      nodeCopy.splice(insertNodeStart + count, 0, node);
       count += 1;
     });
 
-    return superNodeCopy;
+    // Update the index of the new nodes the expanded vis network
+    nodeCopy.forEach((node: Node, index: number) => {
+      node.index = index;
+    });
+    return nodeCopy;
   }
 }
 
@@ -363,6 +369,10 @@ function retractSuperNodeData(
     const superIndexFunc = (superNode: Node) => superNode.id == superNodeName;
     const superIndexStart = expandNodesCopy.findIndex(superIndexFunc);
     expandNodesCopy.splice(superIndexStart + 1, childNodes.length);
+    // Update the index of the new nodes in the retracted vis network
+    expandNodesCopy.forEach((node: Node, index: number) => {
+      node.index = index;
+    });
 
     return expandNodesCopy;
   }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -101,7 +101,7 @@ export function superGraph(nodes: Node[], edges: Link[], attribute: string) {
     nodes: finalNodes,
     links: newLinks,
   };
-  
+
   return network;
 }
 
@@ -232,7 +232,7 @@ function expandSuperNodeData(
       if (node.type === 'node') {
         // look up the child Node's parent if it has one
         const parentNodeID = superChildrenMap.get(node.id);
-        if (parentNodeID) {
+        if (parentNodeID !== undefined) {
           // get the parent node in the list
           const parentIndexFunc = (matrixNode: Node) =>
             matrixNode.id === parentNodeID;
@@ -241,8 +241,6 @@ function expandSuperNodeData(
         }
       }
     });
-
-    console.log(nodeCopy);
     return nodeCopy;
   }
 }

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -222,11 +222,6 @@ function expandSuperNodeData(
       count += 1;
     });
 
-    // Update the index of the new nodes the expanded vis network
-    nodeCopy.forEach((node: Node, index: number) => {
-      node.index = index;
-    });
-
     // Add a parent position value for the child nodes
     nodeCopy.forEach((node: Node) => {
       if (node.type === 'node') {

--- a/src/lib/aggregation.ts
+++ b/src/lib/aggregation.ts
@@ -227,13 +227,11 @@ function expandSuperNodeData(
       node.index = index;
     });
 
-    // Add a parent position value for the regular nodes
+    // Add a parent position value for the child nodes
     nodeCopy.forEach((node: Node) => {
       if (node.type === 'node') {
-        // look up the child Node's parent if it has one
         const parentNodeID = superChildrenMap.get(node.id);
         if (parentNodeID !== undefined) {
-          // get the parent node in the list
           const parentIndexFunc = (matrixNode: Node) =>
             matrixNode.id === parentNodeID;
           const parentNodePosition = nodeCopy.findIndex(parentIndexFunc);


### PR DESCRIPTION
Close #181 
Adds index tracking code to allow for children nodes to drop down from their parent node positions. Exit Transition was not fixed in this PR because of some timing issue with Vue. For column labels, a fade transition was added as well to animate the columns.