### PR TITLE
Table attributes

### DIFF
--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -235,9 +235,14 @@ export default Vue.extend({
           scale.clamp(true);
           scales[col] = scale;
         } else {
-          const values: string[] = this.network.nodes.map(
-            (node: Node) => node[col],
-          );
+          const values: string[] = [];
+          this.network.nodes.forEach((node: Node) => {
+            if (node.type === 'supernode') {
+              values.push(node['GROUP']);
+            } else {
+              values.push(node[col]);
+            }
+          });
           const domain = [...new Set(values)];
           const scale = scaleOrdinal(schemeCategory10).domain(domain);
 
@@ -1193,7 +1198,11 @@ export default Vue.extend({
           if (this.isQuantitative(varName)) {
             return '#82b1ff';
           } else {
-            return this.attributeScales[varName](d[varName]);
+            if (d.type === 'supernode') {
+              return this.attributeScales[varName](d['GROUP']);
+            } else {
+              return this.attributeScales[varName](d[varName]);
+            }
           }
         })
         .attr('cursor', 'pointer')

--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -235,12 +235,11 @@ export default Vue.extend({
           scale.clamp(true);
           scales[col] = scale;
         } else {
-          const values: string[] = [];
-          this.network.nodes.forEach((node: Node) => {
+          const values: string[] = this.network.nodes.map((node: Node) => {
             if (node.type === 'supernode') {
-              values.push(node['GROUP']);
+              return node['GROUP'];
             } else {
-              values.push(node[col]);
+              return node[col];
             }
           });
           const domain = [...new Set(values)];


### PR DESCRIPTION
Close #197 
This commit fixes a bug for the attribute table. The bug grouped all the aggregate nodes into a single category when the matrix was grouped in a supernode such as in this image from the multimatrix.app page 
![image](https://user-images.githubusercontent.com/24800816/107690292-d0c18080-6c5e-11eb-8102-e63d2435dd49.png)

The fix is demonstrated below
https://user-images.githubusercontent.com/24800816/107675699-3147c200-6c4d-11eb-8ae1-a4192f819af0.mp4

Remaining issue is #200

