### PR TITLE
Allow for a larger node table (upto 300 nodes per table)

### DIFF
--- a/src/lib/multinet.ts
+++ b/src/lib/multinet.ts
@@ -12,7 +12,7 @@ async function _downloadAllRows(
 
   // If the table is large, don't download the data
   if (
-    (table.count > 100 && tableType === 'node') ||
+    (table.count > 300 && tableType === 'node') ||
     (table.count > 2000 && tableType === 'link')
   ) {
     throw new Error(


### PR DESCRIPTION
Closes #204

Bumps the download limit for a node table to 300 nodes. This make the app work with the boston dataset, again.