### PR TITLE
Fix tooltip x positioning by subracting the sidebar width

### DIFF
--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -83,6 +83,7 @@ export default Vue.extend({
     provenance: any;
     sortKey: string;
     colMargin: number;
+    sidebarWidth: number;
   } {
     return {
       browser: {
@@ -139,6 +140,7 @@ export default Vue.extend({
       provenance: undefined,
       sortKey: '',
       colMargin: 5,
+      sidebarWidth: 256,
     };
   },
 
@@ -1207,7 +1209,7 @@ export default Vue.extend({
       select(this.$refs.tooltip as any).html(message);
 
       select(this.$refs.tooltip as any)
-        .style('left', `${window.pageXOffset + matrix.e}px`)
+        .style('left', `${matrix.e - this.sidebarWidth}px`)
         .style(
           'top',
           `${


### PR DESCRIPTION
Closes #166

Moves the tooltip 256 pixels left, the width of the sidebar. The variable I'm using to track this could eventually end up in the vuex store, similar to how it is on the MultiLink application.