### PR TITLE
Fix api route in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "dist/"
 command = "yarn build"
 
 [context.production.environment]
-VUE_APP_MULTINET_HOST = "https://api.multinet.app/api"
+VUE_APP_MULTINET_HOST = "https://api.multinet.app"
 
 [context.deploy-preview.environment]
-VUE_APP_MULTINET_HOST = "https://api.multinet.app/api"
+VUE_APP_MULTINET_HOST = "https://api.multinet.app"


### PR DESCRIPTION
There's an extra /api on the live server. This problem was from netlify.toml