### PR TITLE
Fix auto select neighbor toggle

### DIFF
--- a/src/components/MultiMatrix/MultiMatrix.vue
+++ b/src/components/MultiMatrix/MultiMatrix.vue
@@ -1838,7 +1838,7 @@ export default Vue.extend({
         });
       });
 
-      if (selections.length > 0) {
+      if (selections.length > 0 && this.selectNeighbors) {
         selectAll(selections.join(',')).classed('neighbor', true);
       }
     },


### PR DESCRIPTION
Closes #91

Small fix to enable the controls toggle to work. When toggled off, don't highlight neighbors at all (also removes all neighbors on another select).