### PR TITLE
Mount matrix when the network is available

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -22,11 +22,13 @@ export default {
       workspaceName: workspace,
       networkName,
     });
+    const network = computed(() => store.state.network);
 
     const loadError = computed(() => store.state.loadError);
 
     return {
       loadError,
+      network,
     };
   },
 };
@@ -37,7 +39,7 @@ export default {
     <v-content>
       <controls />
 
-      <multi-matrix />
+      <multi-matrix v-if="network !== null" />
 
       <alert v-if="loadError.message !== ''" />
     </v-content>


### PR DESCRIPTION
Closes #251

Adds a v-if to only show the matrix once the network has loaded and is not null. This fixes the banner issue that was referenced in #251