### PR TITLE
Make sure indices are unique before setting selection in lineup

### DIFF
--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -103,7 +103,7 @@ export default {
     // Update selection/hover from matrix
     watchEffect(() => {
       // Convert the ids to indices
-      const indices = idsToIndices([...selectedNodes.value, ...hoveredNodes.value]);
+      const indices = [...new Set(idsToIndices([...selectedNodes.value, ...hoveredNodes.value]))];
 
       if (lineup.value !== null) {
         lineup.value.setSelection(indices);


### PR DESCRIPTION
Closes #267

The crash was caused by a duplicated index value being included in the selection array. I fixed it by converting to set and back before passing the array to the lineup