### PR TITLE
Move network variables to store

### DIFF
--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -87,8 +87,8 @@ export default {
     const displayedHops = computed(() => 2 * selectedHops.value + 1);
 
     const selectedVariables: Ref<string[]> = ref([]);
-    const nodeVariableItems = computed(() => (store.state.network ? Object.keys(store.state.network.nodes[0]) : ['No network']));
-    const edgeVariableItems = computed(() => (store.state.network ? Object.keys(store.state.network.edges[0]) : ['No network']));
+    const nodeVariableItems = computed(() => (store.state.network ? Object.keys(store.state.nodeAttributes) : ['No network']));
+    const edgeVariableItems = computed(() => (store.state.network ? Object.keys(store.state.edgeAttributes) : ['No network']));
 
     const selectedQueryOptions: Ref<string[]> = ref([]);
     const queryOptionItems = ['is (exact)', 'contains'];
@@ -106,9 +106,8 @@ export default {
     watchEffect(() => {
       selectedVariables.value.forEach((variable: string, i: number) => {
         if (store.state.network !== null) {
-          const currentData = i % 2 ? store.state.network.edges : store.state.network.nodes;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          variableValueItems.value[i] = (currentData as any).map((d: any) => `${d[variable]}`).sort();
+          const currentData = i % 2 ? store.state.edgeAttributes : store.state.nodeAttributes;
+          variableValueItems.value[i] = currentData[variable];
         }
       });
     });

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -107,7 +107,7 @@ export default {
       selectedVariables.value.forEach((variable: string, i: number) => {
         if (store.state.network !== null) {
           const currentData = i % 2 ? store.state.edgeAttributes : store.state.nodeAttributes;
-          variableValueItems.value[i] = currentData[variable];
+          variableValueItems.value[i] = currentData[variable].map((value) => `${value}`);
         }
       });
     });

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -107,7 +107,9 @@ export default {
       selectedVariables.value.forEach((variable: string, i: number) => {
         if (store.state.network !== null) {
           const currentData = i % 2 ? store.state.edgeAttributes : store.state.nodeAttributes;
-          variableValueItems.value[i] = currentData[variable].map((value) => `${value}`);
+          if (variable) {
+            variableValueItems.value[i] = currentData[variable].map((value) => `${value}`);
+          }
         }
       });
     });

--- a/src/components/FilterOverlay.vue
+++ b/src/components/FilterOverlay.vue
@@ -57,7 +57,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import api from '@/api';
-import { Network } from '@/types';
+import { ArangoAttributes, Network } from '@/types';
 import store from '@/store';
 
 export default Vue.extend({
@@ -150,8 +150,8 @@ export default Vue.extend({
 
           const nodeAttrDict: {[key: string]: number} = {};
           const edgeAttrDict: {[key: string]: number} = {};
-          const nodeAttributes: {[key: string]: string[] | unknown[]} = {};
-          const edgeAttributes: {[key: string]: string[] | unknown[]} = {};
+          const nodeAttributes: ArangoAttributes = {};
+          const edgeAttributes: ArangoAttributes = {};
 
           const getKeyByValue = (obj: {[key: string]: string | number | boolean }, value: string | number | boolean) => Object.keys(obj)[Object.values(obj).indexOf(value)];
 
@@ -172,7 +172,7 @@ export default Vue.extend({
           for (const [key, value] of Object.entries(edgeAttrDict)) {
             edgeAttributes[key] = [...new Set(aqlResults.edgeValues.map((vals: string[]) => `${vals[value]}`).sort())];
           }
-          store.commit.setLargeNetworkAttributeValues(nodeAttributes, edgeAttributes);
+          store.commit.setLargeNetworkAttributeValues({ nodeAttributes, edgeAttributes });
         });
       }
     },

--- a/src/components/FilterOverlay.vue
+++ b/src/components/FilterOverlay.vue
@@ -120,6 +120,60 @@ export default Vue.extend({
             });
           }
         });
+        this.getAttributes();
+      }
+    },
+    getAttributes() {
+      const aqlQuery = `
+      let nodeValues = (FOR doc IN ${store.state.nodeTableNames}[**] RETURN VALUES(doc))
+      let edgeValues = (FOR doc IN ${store.state.edgeTableName} RETURN VALUES(doc))
+      let nodeAttr = (FOR doc IN ${store.state.nodeTableNames}[**] LIMIT 1 RETURN doc)
+      let edgeAttr = (FOR doc IN ${store.state.edgeTableName} LIMIT 1 RETURN doc)
+      RETURN {nodeAttributes: nodeAttr, nodeValues: nodeValues, edgeAttributes: edgeAttr, edgeValues: edgeValues}
+      `;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let nodeAndEdgeQuery: Promise<any[]> | undefined;
+      try {
+        nodeAndEdgeQuery = api.aql(store.state.workspaceName || '', aqlQuery);
+      } catch (error) {
+        // Add error message for user
+        if (error.status === 400) {
+          store.commit.setLoadError({
+            message: error.statusText,
+            href: 'https://multinet.app',
+          });
+        }
+      }
+      if (nodeAndEdgeQuery !== undefined) {
+        nodeAndEdgeQuery.then((promise) => {
+          const aqlResults = promise[0];
+
+          const nodeAttrDict: {[key: string]: number} = {};
+          const edgeAttrDict: {[key: string]: number} = {};
+          const nodeAttributes: {[key: string]: string[] | unknown[]} = {};
+          const edgeAttributes: {[key: string]: string[] | unknown[]} = {};
+
+          const getKeyByValue = (obj: {[key: string]: string | number | boolean }, value: string | number | boolean) => Object.keys(obj)[Object.values(obj).indexOf(value)];
+
+          Array(aqlResults.nodeValues[0].length).fill(1).forEach((_, i) => {
+            const attrKey: string = getKeyByValue(aqlResults.nodeAttributes[0], aqlResults.nodeValues[0][i]);
+            nodeAttrDict[attrKey] = i;
+          });
+          // eslint-disable-next-line no-restricted-syntax
+          for (const [key, value] of Object.entries(nodeAttrDict)) {
+            nodeAttributes[key] = [...new Set(aqlResults.nodeValues.map((vals: string[]) => `${vals[value]}`).sort())];
+          }
+
+          Array(aqlResults.edgeValues[0].length).fill(1).forEach((_, i) => {
+            const attrKey: string = getKeyByValue(aqlResults.edgeAttributes[0], aqlResults.edgeValues[0][i]);
+            edgeAttrDict[attrKey] = i;
+          });
+          // eslint-disable-next-line no-restricted-syntax
+          for (const [key, value] of Object.entries(edgeAttrDict)) {
+            edgeAttributes[key] = [...new Set(aqlResults.edgeValues.map((vals: string[]) => `${vals[value]}`).sort())];
+          }
+          store.commit.setLargeNetworkAttributeValues(nodeAttributes, edgeAttributes);
+        });
       }
     },
   },

--- a/src/components/FilterOverlay.vue
+++ b/src/components/FilterOverlay.vue
@@ -123,6 +123,7 @@ export default Vue.extend({
         this.getAttributes();
       }
     },
+
     getAttributes() {
       const aqlQuery = `
       let nodeValues = (FOR doc IN ${store.state.nodeTableNames}[**] RETURN VALUES(doc))

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -239,13 +239,17 @@ const {
     },
 
     setAttributeValues(state, network: Network) {
-      const nodeKeys = Object.keys(network.nodes[0]);
+      const allNodeKeys: Set<string> = new Set();
+      network.nodes.forEach((node: Node) => Object.keys(node).forEach((key) => allNodeKeys.add(key)));
+      const nodeKeys = [...allNodeKeys];
       state.nodeAttributes = nodeKeys.reduce((ac, a) => ({ ...ac, [a]: [] }), {});
       nodeKeys.forEach((key: string) => {
         state.nodeAttributes[key] = [...new Set(network.nodes.map((n: Node) => `${n[key]}`).sort())];
       });
 
-      const edgeKeys = Object.keys(network.edges[0]);
+      const allEdgeKeys: Set<string> = new Set();
+      network.edges.forEach((edge: Edge) => Object.keys(edge).forEach((key) => allEdgeKeys.add(key)));
+      const edgeKeys = [...allEdgeKeys];
       state.edgeAttributes = edgeKeys.reduce((ac, a) => ({ ...ac, [a]: [] }), {});
       edgeKeys.forEach((key: string) => {
         state.edgeAttributes[key] = [...new Set(network.edges.map((e: Edge) => `${e[key]}`).sort())];

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -250,6 +250,11 @@ const {
         state.edgeAttributes[key] = [...new Set(network.edges.map((e: Edge) => `${e[key]}`).sort())];
       });
     },
+
+    setLargeNetworkAttributeValues(state: State, nodeAttributes: {[key: string]: string[]}, edgeAttributes: {[key: string]: string[]}) {
+      state.nodeAttributes = nodeAttributes;
+      state.edgeAttributes = edgeAttributes;
+    },
   },
   actions: {
     async fetchNetwork(context, { workspaceName, networkName }) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -57,6 +57,8 @@ const {
     edgeTableName: null,
     provenance: null,
     showProvenanceVis: false,
+    nodeAttributes: {},
+    edgeAttributes: {},
   } as State,
 
   getters: {
@@ -234,6 +236,20 @@ const {
     toggleShowProvenanceVis(state) {
       state.showProvenanceVis = !state.showProvenanceVis;
     },
+
+    setAttributeValues(state, network: Network) {
+      const nodeKeys = Object.keys(network.nodes[0]);
+      state.nodeAttributes = nodeKeys.reduce((ac, a) => ({ ...ac, [a]: [] }), {});
+      nodeKeys.forEach((key: string) => {
+        state.nodeAttributes[key] = [...new Set(network.nodes.map((n: Node) => `${n[key]}`).sort())];
+      });
+
+      const edgeKeys = Object.keys(network.edges[0]);
+      state.edgeAttributes = edgeKeys.reduce((ac, a) => ({ ...ac, [a]: [] }), {});
+      edgeKeys.forEach((key: string) => {
+        state.edgeAttributes[key] = [...new Set(network.edges.map((e: Edge) => `${e[key]}`).sort())];
+      });
+    },
   },
   actions: {
     async fetchNetwork(context, { workspaceName, networkName }) {
@@ -326,6 +342,7 @@ const {
         nodes: nodes as Node[],
         edges: edges as Edge[],
       };
+      commit.setAttributeValues(network);
       dispatch.updateNetwork({ network });
     },
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -251,9 +251,9 @@ const {
       });
     },
 
-    setLargeNetworkAttributeValues(state: State, nodeAttributes: {[key: string]: string[]}, edgeAttributes: {[key: string]: string[]}) {
-      state.nodeAttributes = nodeAttributes;
-      state.edgeAttributes = edgeAttributes;
+    setLargeNetworkAttributeValues(state: State, payload: { nodeAttributes: {[key: string]: string[]}; edgeAttributes: {[key: string]: string[]}}) {
+      state.nodeAttributes = payload.nodeAttributes;
+      state.edgeAttributes = payload.edgeAttributes;
     },
   },
   actions: {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,6 +11,7 @@ import {
   GraphSpec, RowsSpec, TableRow, UserSpec,
 } from 'multinet';
 import {
+  ArangoAttributes,
   Cell,
   Edge, LoadError, Network, Node, ProvenanceEventTypes, State,
 } from '@/types';
@@ -251,7 +252,7 @@ const {
       });
     },
 
-    setLargeNetworkAttributeValues(state: State, payload: { nodeAttributes: {[key: string]: string[]}; edgeAttributes: {[key: string]: string[]}}) {
+    setLargeNetworkAttributeValues(state: State, payload: { nodeAttributes: ArangoAttributes; edgeAttributes: ArangoAttributes }) {
       state.nodeAttributes = payload.nodeAttributes;
       state.edgeAttributes = payload.edgeAttributes;
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,8 @@ export interface State {
   edgeTableName: string | null;
   provenance: Provenance<State, ProvenanceEventTypes, unknown> | null;
   showProvenanceVis: boolean;
+  nodeAttributes: {[key: string]: string[]};
+  edgeAttributes: {[key: string]: string[]};
 }
 
 export type ProvenanceEventTypes =

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,10 @@ export interface LoadError {
   href: string;
 }
 
+export interface ArangoAttributes {
+  [key: string]: unknown[];
+}
+
 export interface State {
   workspaceName: string | null;
   networkName: string | null;
@@ -66,8 +70,8 @@ export interface State {
   edgeTableName: string | null;
   provenance: Provenance<State, ProvenanceEventTypes, unknown> | null;
   showProvenanceVis: boolean;
-  nodeAttributes: {[key: string]: string[]};
-  edgeAttributes: {[key: string]: string[]};
+  nodeAttributes: ArangoAttributes;
+  edgeAttributes: ArangoAttributes;
 }
 
 export type ProvenanceEventTypes =


### PR DESCRIPTION
Closes #281 

This change will make it possible to switch between queries without refreshing the page.
It will also show all possible options for large networks because it will pull the values from the original network.