### PR TITLE
Remove all child node logic, child nodes are now "normal" nodes

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -67,10 +67,6 @@ export default Vue.extend({
       return store.state.aggregated;
     },
 
-    showChildLegend() {
-      return store.state.showChildLegend;
-    },
-
     cellColorScale() {
       return store.getters.cellColorScale;
     },
@@ -79,12 +75,12 @@ export default Vue.extend({
       return store.getters.parentColorScale;
     },
 
-    childColorScale() {
-      return store.getters.childColorScale;
-    },
-
     nodeVariableItems() {
       return store.getters.nodeVariableItems;
+    },
+
+    maxConnections() {
+      return store.state.maxConnections;
     },
   },
 
@@ -95,10 +91,6 @@ export default Vue.extend({
 
     parentColorScale() {
       this.updateLegend(this.parentColorScale, 'parent');
-    },
-
-    childColorScale() {
-      this.updateLegend(this.childColorScale, 'child');
     },
   },
 
@@ -114,15 +106,14 @@ export default Vue.extend({
       a.click();
     },
 
-    updateLegend(colorScale: ScaleLinear<string, number>, legendName: 'parent' | 'child' | 'unAggr') {
+    updateLegend(colorScale: ScaleLinear<string, number>, legendName: 'parent' | 'unAggr') {
       let legendSVG;
       if (legendName === 'parent') {
         legendSVG = select('#parent-matrix-legend');
-      } else if (legendName === 'child') {
-        legendSVG = select('#child-matrix-legend');
       } else {
         legendSVG = select('#matrix-legend');
       }
+
       legendSVG
         .append('g')
         .classed('legendLinear', true)
@@ -314,22 +305,11 @@ export default Vue.extend({
 
           <!-- Matrix Legend -->
           <v-list-item
-            v-else
             class="pb-0 px-0"
-            style="display: flex; max-height: 50px"
+            :style="`display: flex; max-height: 50px; opacity: ${maxConnections.unAggr > 0 ? 1 : 0}`"
           >
-            Matrix Legend
+            {{ aggregated ? 'Child Legend' : 'Matrix Legend' }}
             <svg id="matrix-legend" />
-          </v-list-item>
-
-          <!-- Child Matrix Legend -->
-          <v-list-item
-            v-if="showChildLegend"
-            class="pb-0 px-0"
-            style="display: flex; max-height: 50px"
-          >
-            Children Legend
-            <svg id="child-matrix-legend" />
           </v-list-item>
         </div>
         <div v-if="connectivityQueryToggle">

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -166,10 +166,6 @@ export default Vue.extend({
     parentColorScale() {
       return store.getters.parentColorScale;
     },
-
-    childColorScale() {
-      return store.getters.childColorScale;
-    },
   },
 
   watch: {
@@ -306,7 +302,6 @@ export default Vue.extend({
       // Reset some values that will be re-calcuated
       let maxNumConnections = 0;
       let maxAggrConnections = 0;
-      let maxChildConnections = 0;
       this.matrix = [];
 
       if (this.network !== null) {
@@ -345,7 +340,6 @@ export default Vue.extend({
           ) {
             if (cell.z > maxNumConnections) {
               maxNumConnections = cell.z;
-              maxChildConnections = cell.z;
             }
           }
           if (
@@ -362,7 +356,6 @@ export default Vue.extend({
       store.commit.setMaxConnections({
         unAggr: maxNumConnections,
         parent: maxAggrConnections,
-        child: maxChildConnections,
       });
     },
 
@@ -552,12 +545,7 @@ export default Vue.extend({
       // add foreign objects for label
       rowEnter
         .append('foreignObject')
-        .attr('x', (d: Node) => {
-          if (d.type === 'childnode') {
-            return -rowLabelContainerStart + 29;
-          }
-          return -rowLabelContainerStart + 20;
-        })
+        .attr('x', -rowLabelContainerStart + 29)
         .attr('y', -5)
         .attr('width', (d: Node) => {
           if (d.type === 'supernode') {
@@ -591,12 +579,7 @@ export default Vue.extend({
       // Invisible Rectangles for Foreign Row Labels
       rowEnter
         .append('rect')
-        .attr('x', (d: Node) => {
-          if (d.type === 'childnode') {
-            return -rowLabelContainerStart + 29;
-          }
-          return -rowLabelContainerStart + 20;
-        })
+        .attr('x', -rowLabelContainerStart + 20)
         .attr('y', 0)
         .attr('width', labelContainerWidth - 25)
         .attr('height', 15)
@@ -664,7 +647,7 @@ export default Vue.extend({
         .on('click', (event: MouseEvent, node: Node) => {
           // allow expanding the vis if aggregation is turned on
           if (this.aggregated) {
-            if (node.type === 'childnode') {
+            if (node.type !== 'supernode') {
               return;
             }
             // expand and retract the supernode aggregation based on user selection
@@ -672,15 +655,10 @@ export default Vue.extend({
               // retract
               this.expandedSuperNodes.delete(node._id);
               store.dispatch.retractAggregatedNode(node._id);
-
-              if (this.expandedSuperNodes.size === 0) {
-                store.commit.setShowChildLegend(false);
-              }
             } else {
               // expand
               this.expandedSuperNodes.add(node._id);
               store.dispatch.expandAggregatedNode(node._id);
-              store.commit.setShowChildLegend(true);
             }
           } else {
             store.commit.clickElement(node._id);
@@ -712,9 +690,6 @@ export default Vue.extend({
         .style('fill', (d: Cell) => {
           if (d.rowCellType === 'supernode' && d.colCellType === 'supernode') {
             return this.parentColorScale(d.z);
-          }
-          if (d.rowCellType === 'childnode' || d.colCellType === 'childnode') {
-            return this.childColorScale(d.z);
           }
           return this.cellColorScale(d.z);
         })
@@ -749,9 +724,6 @@ export default Vue.extend({
         .style('fill', (d: Cell) => {
           if (d.rowCellType === 'supernode' && d.colCellType === 'supernode') {
             return this.parentColorScale(d.z);
-          }
-          if (d.rowCellType === 'childnode' || d.colCellType === 'childnode') {
-            return this.childColorScale(d.z);
           }
           return this.cellColorScale(d.z);
         })

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -46,13 +46,11 @@ const {
     showGridLines: true,
     enableAggregation: false,
     aggregated: false,
-    showChildLegend: false,
     visualizedNodeAttributes: [],
     visualizedEdgeAttributes: [],
     maxConnections: {
       unAggr: 0,
       parent: 0,
-      child: 0,
     },
     nodeTableNames: [],
     edgeTableName: null,
@@ -73,12 +71,6 @@ const {
       return scaleLinear<string, number>()
         .domain([0, state.maxConnections.parent])
         .range(['#dcedfa', '#0066cc']);
-    },
-
-    childColorScale(state): ScaleLinear<string, number> {
-      return scaleLinear<string, number>()
-        .domain([0, state.maxConnections.child])
-        .range(['#f79d97', '#c0362c']);
     },
 
     nodeVariableItems(state): string[] {
@@ -218,14 +210,9 @@ const {
       state.aggregated = aggregated;
     },
 
-    setShowChildLegend(state, showChildLegend: boolean) {
-      state.showChildLegend = showChildLegend;
-    },
-
     setMaxConnections(state, maxConnections: {
       unAggr: number;
       parent: number;
-      child: number;
     }) {
       state.maxConnections = maxConnections;
     },
@@ -581,7 +568,6 @@ const {
         });
 
         store.commit.setAggregated(false);
-        store.commit.setShowChildLegend(false);
         dispatch.updateNetwork({ network: { nodes: allChildren, edges: originalEdges } });
       }
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,11 +61,9 @@ export interface State {
   showGridLines: boolean;
   enableAggregation: boolean;
   aggregated: boolean;
-  showChildLegend: boolean;
   maxConnections: {
     unAggr: number;
     parent: number;
-    child: number;
   };
   nodeTableNames: string[];
   edgeTableName: string | null;


### PR DESCRIPTION
Closes #290

I chose to use one scale for all "normal" nodes and one for super nodes. This means that lots of the child node logic can be removed and simplifies the code quite a bit. 

To keep the child legend, I used a ternary operatore to show/hide the legend and to change the name of the legend.