### PR TITLE
Alleviate grid illusion by removing cell radius and darkening lines

### DIFF
--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -363,9 +363,6 @@ export default Vue.extend({
 
       this.processData();
 
-      // set the radius for cells
-      const cellRadius = 3;
-
       // set the matrix highlight
       const matrixHighlightLength = this.matrix.length * this.cellSize;
 
@@ -672,7 +669,6 @@ export default Vue.extend({
         .attr('y', 1)
         .attr('width', this.cellSize - 2)
         .attr('height', this.cellSize - 2)
-        .attr('rx', cellRadius)
         .style('fill', (d: Cell) => {
           if (d.rowCellType === 'supernode' && d.colCellType === 'supernode') {
             return this.parentColorScale(d.z);
@@ -706,7 +702,6 @@ export default Vue.extend({
         .attr('y', 1)
         .attr('width', this.cellSize - 2)
         .attr('height', this.cellSize - 2)
-        .attr('rx', cellRadius)
         .style('fill', (d: Cell) => {
           if (d.rowCellType === 'supernode' && d.colCellType === 'supernode') {
             return this.parentColorScale(d.z);
@@ -733,7 +728,7 @@ export default Vue.extend({
       const gridLines = this.edges
         .append('g')
         .attr('class', 'gridLines')
-        .style('opacity', this.showGridLines ? 0.3 : 0);
+        .style('opacity', this.showGridLines ? 1 : 0);
 
       const lines = gridLines
         .selectAll('line')
@@ -758,8 +753,7 @@ export default Vue.extend({
         .attr('x1', this.orderingScale.range()[1])
         .attr('x2', this.orderingScale.range()[1])
         .attr('y1', 0)
-        .attr('y2', this.orderingScale.range()[1])
-        .style('stroke', '#aaa');
+        .attr('y2', this.orderingScale.range()[1]);
 
       // horizontal grid line edges
       gridLines
@@ -767,8 +761,7 @@ export default Vue.extend({
         .attr('x1', 0)
         .attr('x2', this.orderingScale.range()[1])
         .attr('y1', this.orderingScale.range()[1])
-        .attr('y2', this.orderingScale.range()[1])
-        .style('stroke', '#aaa');
+        .attr('y2', this.orderingScale.range()[1]);
     },
 
     sort(order: string): void {
@@ -1061,8 +1054,7 @@ svg >>> text.clicked {
 
 svg >>> .gridLines {
   pointer-events: none;
-  stroke: #aaa;
-  opacity: 0.3;
+  stroke: #BBBBBB;
 }
 
 svg >>> g.box line {


### PR DESCRIPTION
Closes #92

Using Roni's/Jared's suggestions and [this article](https://ux.stackexchange.com/questions/53791/avoiding-the-hermann-grid-illusion) I've attempted to fix this problem.

I removed the border radius on the cells and darkened the grid lines. It seems to remove the effect for me, but I'd like a quick sanity check that it works on other machines.