### PR TITLE
Remove internal/arango vars

### DIFF
--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -77,6 +77,7 @@ import {
   computed, ref, Ref, watchEffect,
 } from '@vue/composition-api';
 import api from '@/api';
+import { isInternalField } from '@/lib/typeUtils';
 
 export default {
   name: 'ConnectivityQuery',
@@ -88,7 +89,7 @@ export default {
 
     const selectedVariables: Ref<string[]> = ref([]);
     const nodeVariableItems = computed(() => store.getters.nodeVariableItems);
-    const edgeVariableItems = computed(() => (store.state.network ? Object.keys(store.state.edgeAttributes) : ['No network']));
+    const edgeVariableItems = computed(() => (store.state.network ? Object.keys(store.state.edgeAttributes).filter((varName) => !isInternalField(varName)) : ['No network']));
 
     const selectedQueryOptions: Ref<string[]> = ref([]);
     const queryOptionItems = ['is (exact)', 'contains'];

--- a/src/lib/typeUtils.ts
+++ b/src/lib/typeUtils.ts
@@ -1,0 +1,7 @@
+import { InternalField, internalFieldNames } from '@/types';
+
+// Disable no explicit any, since there are type errors for string and unknown
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isInternalField(candidate: any): candidate is InternalField {
+  return internalFieldNames.includes(candidate);
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -17,6 +17,7 @@ import {
 } from '@/types';
 import { defineNeighbors } from '@/lib/utils';
 import { undoRedoKeyHandler, updateProvenanceState } from '@/lib/provenanceUtils';
+import { isInternalField } from '@/lib/typeUtils';
 
 Vue.use(Vuex);
 
@@ -74,7 +75,10 @@ const {
     },
 
     nodeVariableItems(state): string[] {
-      return state.network ? Object.keys(state.nodeAttributes) : [];
+      if (state.network !== null) {
+        return Object.keys(state.nodeAttributes).filter((varName) => !isInternalField(varName));
+      }
+      return [];
     },
   },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,3 +82,6 @@ export type ProvenanceEventTypes =
   'De-Select Cell' |
   'Select Node' |
   'De-Select Node';
+
+export const internalFieldNames = ['_from', '_to', '_id', '_rev'] as const;
+export type InternalField = (typeof internalFieldNames)[number];


### PR DESCRIPTION
Closes #241

I adopted the logic from MultiLink to filter out internal variables from the list of node variables and link variables. Since the node variables are tracked in the store, it was a simple fix. The link variables also only appear in one spot