### PR TITLE
Replace aggregation UI with a single v-autocomplete

### DIFF
--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -187,7 +187,7 @@ export default {
             });
 
             // Update state with new network
-            store.dispatch.updateEnableAggregation(false);
+            store.dispatch.aggregateNetwork('none');
             store.dispatch.updateNetwork({ network: newNetwork });
           }
         });

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -228,6 +228,18 @@ export default Vue.extend({
             <v-list-item-content> Directional Edges </v-list-item-content>
           </v-list-item>
 
+          <!-- Connectivity Query List Item -->
+          <v-list-item class="px-0">
+            <v-list-item-action class="mr-3">
+              <v-switch
+                v-model="connectivityQueryToggle"
+                class="ma-0"
+                hide-details
+              />
+            </v-list-item-action>
+            <v-list-item-content> Enable Connectivity Query </v-list-item-content>
+          </v-list-item>
+
           <!-- Aggregation Variable Selection -->
           <v-list-item
             class="pa-0 ma-0"
@@ -240,18 +252,6 @@ export default Vue.extend({
                 @change="aggregateNetwork"
               />
             </v-list-item-content>
-          </v-list-item>
-
-          <!-- Connectivity Query List Item -->
-          <v-list-item class="px-0">
-            <v-list-item-action class="mr-3">
-              <v-switch
-                v-model="connectivityQueryToggle"
-                class="ma-0"
-                hide-details
-              />
-            </v-list-item-action>
-            <v-list-item-content> Enable Connectivity Query </v-list-item-content>
           </v-list-item>
 
           <v-list-item class="px-0">

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -19,6 +19,7 @@ export default Vue.extend({
   data() {
     return {
       connectivityQueryToggle: false,
+      aggregateBy: 'none',
     };
   },
 
@@ -246,9 +247,11 @@ export default Vue.extend({
           >
             <v-list-item-content class="pa-0 ma-0">
               <v-autocomplete
+                v-model="aggregateBy"
                 class="pa-0 ma-0"
-                :items="nodeVariableItems"
-                placeholder="Variable to aggregate by"
+                :items="['none', ...nodeVariableItems]"
+                hint="Variable to aggregate by"
+                persistent-hint
                 @change="aggregateNetwork"
               />
             </v-list-item-content>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -84,6 +84,12 @@ export default Vue.extend({
     parentColorScale() {
       this.updateLegend(this.parentColorScale, 'parent');
     },
+
+    aggregated() {
+      if (!this.aggregated) {
+        this.aggregateBy = 'none';
+      }
+    },
   },
 
   methods: {

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -54,15 +54,6 @@ export default Vue.extend({
       },
     },
 
-    enableAggregation: {
-      get() {
-        return store.state.enableAggregation;
-      },
-      set(value: boolean) {
-        store.dispatch.updateEnableAggregation(value);
-      },
-    },
-
     aggregated() {
       return store.state.aggregated;
     },
@@ -237,23 +228,8 @@ export default Vue.extend({
             <v-list-item-content> Directional Edges </v-list-item-content>
           </v-list-item>
 
-          <!-- Aggregation Toggle List Item -->
-          <v-list-item class="px-0">
-            <v-list-item-action class="mr-3">
-              <v-switch
-                v-model="enableAggregation"
-                class="ma-0"
-                hide-details
-              />
-            </v-list-item-action>
-            <v-list-item-content>
-              Enable Aggregation
-            </v-list-item-content>
-          </v-list-item>
-
           <!-- Aggregation Variable Selection -->
           <v-list-item
-            v-if="enableAggregation"
             class="pa-0 ma-0"
           >
             <v-list-item-content class="pa-0 ma-0">

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -11,8 +11,6 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
       provState.showGridLines = newProvState.showGridLines;
     } else if (label === 'Set Directional Edges') {
       provState.directionalEdges = newProvState.directionalEdges;
-    } else if (label === 'Set Enable Aggregation') {
-      provState.enableAggregation = newProvState.enableAggregation;
     } else if (label === 'Select Cell' || label === 'De-Select Cell') {
       provState.selectedCells = newProvState.selectedCells;
     } else if (label === 'Select Node' || label === 'De-Select Node') {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -45,7 +45,6 @@ const {
     directionalEdges: false,
     selectNeighbors: true,
     showGridLines: true,
-    enableAggregation: false,
     aggregated: false,
     visualizedNodeAttributes: [],
     visualizedEdgeAttributes: [],
@@ -199,14 +198,6 @@ const {
 
       if (state.provenance !== null) {
         updateProvenanceState(state, 'Set Show Grid Lines');
-      }
-    },
-
-    setEnableAggregation(state, enableAggregation: boolean) {
-      state.enableAggregation = enableAggregation;
-
-      if (state.provenance !== null) {
-        updateProvenanceState(state, 'Set Enable Aggregation');
       }
     },
 
@@ -548,31 +539,6 @@ const {
           .filter((edge): edge is Edge => edge !== null);
 
         dispatch.updateNetwork({ network: { nodes: retractedNodes, edges: retractedEdges } });
-      }
-    },
-
-    updateEnableAggregation(context, enableAggregation: boolean) {
-      const { state, commit, dispatch } = rootActionContext(context);
-
-      commit.setEnableAggregation(enableAggregation);
-
-      // Reset an aggregated network
-      if (state.aggregated && state.network) {
-        const allChildren = state.network.nodes
-          .map((node) => node.children)
-          .flat()
-          .filter((node): node is Node => node !== undefined);
-
-        const originalEdges = state.network.edges.map((edge) => {
-          const originalEdge = { ...edge };
-          originalEdge._from = `${originalEdge.originalFrom}`;
-          originalEdge._to = `${originalEdge.originalTo}`;
-
-          return originalEdge;
-        });
-
-        store.commit.setAggregated(false);
-        dispatch.updateNetwork({ network: { nodes: allChildren, edges: originalEdges } });
       }
     },
   },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -422,63 +422,86 @@ const {
       const { state, commit, dispatch } = rootActionContext(context);
 
       if (state.network !== null) {
-        // Calculate edges
-        const aggregatedEdges = state.network.edges.map((edge) => {
-          const fromNode = state.network && state.network.nodes.find((node) => node._id === edge._from);
-          const toNode = state.network && state.network.nodes.find((node) => node._id === edge._to);
+        // Reset network if aggregated
+        if (state.aggregated) {
+          // Reset an aggregated network
+          const allChildren = state.network.nodes
+            .map((node) => node.children)
+            .flat()
+            .filter((node): node is Node => node !== undefined);
 
-          if (fromNode === undefined || toNode === undefined || fromNode === null || toNode === null) {
+          const originalEdges = state.network.edges.map((edge) => {
+            const originalEdge = { ...edge };
+            originalEdge._from = `${originalEdge.originalFrom}`;
+            originalEdge._to = `${originalEdge.originalTo}`;
+
+            return originalEdge;
+          });
+
+          store.commit.setAggregated(false);
+          dispatch.updateNetwork({ network: { nodes: allChildren, edges: originalEdges } });
+        }
+
+        // Aggregate the network if the varName is not none
+        if (varName !== 'none') {
+          // Calculate edges
+          const aggregatedEdges = state.network.edges.map((edge) => {
+            const fromNode = state.network && state.network.nodes.find((node) => node._id === edge._from);
+            const toNode = state.network && state.network.nodes.find((node) => node._id === edge._to);
+
+            if (fromNode === undefined || toNode === undefined || fromNode === null || toNode === null) {
+              return edge;
+            }
+
+            const fromNodeValue = fromNode[varName];
+            const toNodeValue = toNode[varName];
+
+            /* eslint-disable no-param-reassign */
+            /* eslint-disable no-underscore-dangle */
+            edge.originalFrom = edge.originalFrom === undefined ? edge._from : edge.originalFrom;
+            edge.originalTo = edge.originalTo === undefined ? edge._to : edge.originalTo;
+            edge._from = `aggregated/${fromNodeValue}`;
+            edge._to = `aggregated/${toNodeValue}`;
+            /* eslint-enable no-param-reassign */
+            /* eslint-enable no-underscore-dangle */
+
             return edge;
-          }
+          });
 
-          const fromNodeValue = fromNode[varName];
-          const toNodeValue = toNode[varName];
+          // Calculate nodes
+          const aggregatedNodes = Array.from(
+            group(state.network.nodes, (d) => d[varName]),
+            ([key, value]) => ({
+              _id: `aggregated/${key}`,
+              _key: `${key}`,
+              children: value.map((node) => JSON.parse(JSON.stringify(node))),
+              type: 'supernode',
+              neighbors: [] as string[],
+              [varName]: key,
+            }),
+          );
 
-          /* eslint-disable no-param-reassign */
-          /* eslint-disable no-underscore-dangle */
-          edge.originalFrom = edge.originalFrom === undefined ? edge._from : edge.originalFrom;
-          edge.originalTo = edge.originalTo === undefined ? edge._to : edge.originalTo;
-          edge._from = `aggregated/${fromNodeValue}`;
-          edge._to = `aggregated/${toNodeValue}`;
-          /* eslint-enable no-param-reassign */
-          /* eslint-enable no-underscore-dangle */
+          // Calculate neighbors
+          aggregatedEdges.forEach((edge) => {
+            const fromNode = aggregatedNodes.find((node) => node._id === edge._from);
+            const toNode = aggregatedNodes.find((node) => node._id === edge._to);
 
-          return edge;
-        });
+            if (fromNode === undefined || toNode === undefined) {
+              return;
+            }
 
-        // Calculate nodes
-        const aggregatedNodes = Array.from(
-          group(state.network.nodes, (d) => d[varName]),
-          ([key, value]) => ({
-            _id: `aggregated/${key}`,
-            _key: `${key}`,
-            children: value.map((node) => JSON.parse(JSON.stringify(node))),
-            type: 'supernode',
-            neighbors: [] as string[],
-            [varName]: key,
-          }),
-        );
+            if (edge._to !== fromNode._id && fromNode.neighbors.indexOf(edge._to) === -1) {
+              fromNode.neighbors.push(edge._to);
+            }
+            if (edge._from !== toNode._id && toNode.neighbors.indexOf(edge._from) === -1) {
+              toNode.neighbors.push(edge._from);
+            }
+          });
 
-        // Calculate neighbors
-        aggregatedEdges.forEach((edge) => {
-          const fromNode = aggregatedNodes.find((node) => node._id === edge._from);
-          const toNode = aggregatedNodes.find((node) => node._id === edge._to);
-
-          if (fromNode === undefined || toNode === undefined) {
-            return;
-          }
-
-          if (edge._to !== fromNode._id && fromNode.neighbors.indexOf(edge._to) === -1) {
-            fromNode.neighbors.push(edge._to);
-          }
-          if (edge._from !== toNode._id && toNode.neighbors.indexOf(edge._from) === -1) {
-            toNode.neighbors.push(edge._from);
-          }
-        });
-
-        // Set network and aggregated
-        commit.setAggregated(true);
-        dispatch.updateNetwork({ network: { nodes: aggregatedNodes, edges: aggregatedEdges } });
+          // Set network and aggregated
+          commit.setAggregated(true);
+          dispatch.updateNetwork({ network: { nodes: aggregatedNodes, edges: aggregatedEdges } });
+        }
       }
     },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,7 +59,6 @@ export interface State {
   directionalEdges: boolean;
   selectNeighbors: boolean;
   showGridLines: boolean;
-  enableAggregation: boolean;
   aggregated: boolean;
   maxConnections: {
     unAggr: number;
@@ -77,7 +76,6 @@ export type ProvenanceEventTypes =
   'Set Select Neighbors' |
   'Set Show Grid Lines' |
   'Set Directional Edges' |
-  'Set Enable Aggregation' |
   'Select Cell' |
   'De-Select Cell' |
   'Select Node' |


### PR DESCRIPTION
Closes #291

Replace the enable aggregation switch and drop down with a single v-autocomplete that handles it all. The default is `'none'`. This provides a slightly better UX since a user can now switch between variables without disabling the aggregation first, and there are less click in general.