### PR TITLE
Use defineComponent in each component

### DIFF
--- a/src/components/AboutDialog.vue
+++ b/src/components/AboutDialog.vue
@@ -54,9 +54,9 @@
 </template>
 
 <script lang="ts">
-import { ref } from '@vue/composition-api';
+import { defineComponent, ref } from '@vue/composition-api';
 
-export default {
+export default defineComponent({
   setup() {
     const dialog = ref(false);
 
@@ -64,6 +64,6 @@ export default {
       dialog,
     };
   },
-};
+});
 
 </script>

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -1,12 +1,12 @@
 <script lang="ts">
 import store from '@/store';
 import {
-  computed, Ref, ref, watchEffect,
+  computed, defineComponent, Ref, ref, watchEffect,
 } from '@vue/composition-api';
 import api from '@/api';
 import FilterOverlay from '@/components/FilterOverlay.vue';
 
-export default {
+export default defineComponent({
   name: 'Alert',
 
   components: {
@@ -59,7 +59,7 @@ export default {
       workspaceOptions,
     };
   },
-};
+});
 </script>
 
 <template>

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -74,12 +74,12 @@
 import store from '@/store';
 import { Node, Edge, Network } from '@/types';
 import {
-  computed, ref, Ref, watchEffect,
+  computed, defineComponent, ref, Ref, watchEffect,
 } from '@vue/composition-api';
 import api from '@/api';
 import { isInternalField } from '@/lib/typeUtils';
 
-export default {
+export default defineComponent({
   name: 'ConnectivityQuery',
 
   setup() {
@@ -217,5 +217,5 @@ export default {
       submitQuery,
     };
   },
-};
+});
 </script>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -7,9 +7,11 @@ import store from '@/store';
 import AboutDialog from '@/components/AboutDialog.vue';
 import LoginMenu from '@/components/LoginMenu.vue';
 import ConnectivityQuery from '@/components/ConnectivityQuery.vue';
-import { computed, ref, watchEffect } from '@vue/composition-api';
+import {
+  computed, defineComponent, ref, watchEffect,
+} from '@vue/composition-api';
 
-export default {
+export default defineComponent({
   components: {
     AboutDialog,
     LoginMenu,
@@ -137,7 +139,7 @@ export default {
       aggregateNetwork,
     };
   },
-};
+});
 </script>
 
 <template>

--- a/src/components/FilterOverlay.vue
+++ b/src/components/FilterOverlay.vue
@@ -58,9 +58,9 @@
 import api from '@/api';
 import { ArangoAttributes, Network } from '@/types';
 import store from '@/store';
-import { computed, ref } from '@vue/composition-api';
+import { computed, defineComponent, ref } from '@vue/composition-api';
 
-export default {
+export default defineComponent({
   setup() {
     const subsetAmount = ref(0);
     const workspace = computed(() => store.state.workspaceName);
@@ -178,5 +178,5 @@ export default {
       getAttributes,
     };
   },
-};
+});
 </script>

--- a/src/components/IntermediaryNodes.vue
+++ b/src/components/IntermediaryNodes.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  computed, onMounted, watch,
+  computed, defineComponent, onMounted, watch,
 } from '@vue/composition-api';
 import {
   scaleLinear,
@@ -9,7 +9,7 @@ import { select } from 'd3-selection';
 import store from '@/store';
 import { ConnectivityCell } from '@/types';
 
-export default {
+export default defineComponent({
   name: 'IntermediaryNodes',
 
   setup() {
@@ -198,7 +198,7 @@ export default {
       matrixHeight,
     };
   },
-};
+});
 </script>
 
 <template>

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -1,12 +1,12 @@
 <script lang="ts">
 import store from '@/store';
 import {
-  computed, onMounted, Ref, ref, SetupContext, watch, watchEffect,
+  computed, defineComponent, onMounted, Ref, ref, SetupContext, watch, watchEffect,
 } from '@vue/composition-api';
 import LineUp, { DataBuilder } from 'lineupjs';
 import { select } from 'd3-selection';
 
-export default {
+export default defineComponent({
   name: 'LineUp',
 
   setup(props: unknown, context: SetupContext) {
@@ -162,7 +162,7 @@ export default {
       removeHighlight,
     };
   },
-};
+});
 </script>
 
 <template>

--- a/src/components/LoginMenu.vue
+++ b/src/components/LoginMenu.vue
@@ -63,9 +63,11 @@
 <script lang="ts">
 import { host } from '@/environment';
 import store from '@/store';
-import { computed, ref, watchEffect } from '@vue/composition-api';
+import {
+  computed, defineComponent, ref, watchEffect,
+} from '@vue/composition-api';
 
-export default {
+export default defineComponent({
   setup() {
     const menu = ref(false);
     const location = ref('');
@@ -105,7 +107,7 @@ export default {
       userInfo,
     };
   },
-};
+});
 </script>
 
 <style scoped>

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -19,13 +19,13 @@ import IntermediaryNodes from '@/components/IntermediaryNodes.vue';
 import 'science';
 import 'reorder.js';
 import {
-  computed, onMounted, Ref, ref, watch, watchEffect,
+  computed, defineComponent, onMounted, Ref, ref, watch, watchEffect,
 } from '@vue/composition-api';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const reorder: any;
 
-export default {
+export default defineComponent({
   components: {
     LineUp,
     IntermediaryNodes,
@@ -884,7 +884,7 @@ export default {
     };
   },
 
-};
+});
 </script>
 
 <template>

--- a/src/components/ProvVis.vue
+++ b/src/components/ProvVis.vue
@@ -1,11 +1,13 @@
 <script lang="ts">
 import { ProvVisCreator } from '@visdesignlab/trrack-vis';
 import { ProvenanceEventTypes, State } from '@/types';
-import { computed, ComputedRef, onMounted } from '@vue/composition-api';
+import {
+  computed, ComputedRef, defineComponent, onMounted,
+} from '@vue/composition-api';
 import store from '@/store';
 import { Provenance } from '@visdesignlab/trrack';
 
-export default {
+export default defineComponent({
   setup() {
     const provenance: ComputedRef<Provenance<State, ProvenanceEventTypes, unknown> | null> = computed(
       () => store.state.provenance,
@@ -31,7 +33,7 @@ export default {
 
     return { toggleProvVis };
   },
-};
+});
 </script>
 
 <template>


### PR DESCRIPTION
This is an improvement that I found doing some work on MultiLink (with the help of Roni and Jake). We need to use `defineComponent` when using props (which we're not), but it's probably just best to use it all the time. This means that if we want to use a new feature, we'll likely get the typescript support through this function