### PR TITLE
Fix the selected cells watcher

### DIFF
--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -326,7 +326,7 @@ export default {
         .classed('neighbor', (node) => neighborsOfClicked.indexOf(node._id) !== -1 && selectNeighbors.value);
     });
 
-    watchEffect(() => {
+    watch(selectedCells, () => {
       // Apply cell highlight
       selectAll('.cellsGroup')
         .selectAll('.cell')


### PR DESCRIPTION
After my recent changes to the composition API, I noticed that the cells weren't able to be selected. This code fixes that issue