### PR TITLE
Make the linter fail on warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "test": "vue-cli-service test:unit",
-    "lint": "vue-cli-service lint --no-fix",
+    "lint": "vue-cli-service lint --max-warnings=0 --no-fix",
     "lint:fix": "vue-cli-service lint",
     "test:unit": "vue-cli-service test:unit"
   },


### PR DESCRIPTION
This will make the `yarn lint` command function the same way it does on multilink and the client. 

A byproduct of this change is that it will be harder to commit code that doens't pass the linter's validation. This could cause some more work when coding, but it will mean that it won't need to be tidied up on PR review.

You can always bypass this with `git commit -m "message" --no-verify` if we're going to defer the work until the review is over