### PR TITLE
Make int nodes table reactive to cell size

### DIFF
--- a/src/components/IntermediaryNodes.vue
+++ b/src/components/IntermediaryNodes.vue
@@ -127,7 +127,6 @@ export default defineComponent({
 
     function buildIntView() {
       if (matrix.length > 0) {
-        const labelPadding = 10;
         const headerPadding = 5;
         const circleRadius = cellSize.value / 2;
         const cellFontSize = cellSize.value * 0.8;
@@ -199,7 +198,6 @@ export default defineComponent({
           .each(makeRow)
           .append('text')
           .attr('class', 'rowLabels')
-          .attr('x', -cellFontSize - labelPadding)
           .attr('y', 5)
           .style('font-size', `${cellFontSize}px`)
           .attr('dominant-baseline', 'hanging')

--- a/src/components/IntermediaryNodes.vue
+++ b/src/components/IntermediaryNodes.vue
@@ -219,7 +219,7 @@ export default defineComponent({
       buildIntView();
     });
 
-    watch(connectivityPaths, () => {
+    watch([connectivityPaths, cellSize], () => {
       processData();
       teardownOldView();
       buildIntView();

--- a/src/components/IntermediaryNodes.vue
+++ b/src/components/IntermediaryNodes.vue
@@ -129,8 +129,9 @@ export default defineComponent({
 
     function buildIntView() {
       if (matrix.length > 0) {
+        const cellFontSize = cellSize.value * 0.8;
+
         const svg = select('#intNode').append('g').attr('transform', `translate(${margin.left},${margin.top})`);
-        const rowLabelWidth = 20;
 
         //   Draw path symbols
         const circles = svg.selectAll('g.circles')
@@ -150,7 +151,7 @@ export default defineComponent({
           .attr('x', (_, i) => xScale.value(i))
           .attr('y', cellSize.value / 2 - 3)
           .attr('text-anchor', 'middle')
-          .attr('font-size', `${cellSize.value - 2}px`)
+          .attr('font-size', `${cellFontSize}px`)
           .text((_, i) => i + 1);
 
         //   Draw gridlines
@@ -204,8 +205,7 @@ export default defineComponent({
           .each(makeRow)
           .append('text')
           .attr('class', 'rowLabels')
-          .attr('y', cellSize.value / 2 + 5)
-          .attr('x', -(matrixWidth.value / 5 + rowLabelWidth))
+          .style('font-size', `${cellFontSize}px`)
           .text((_, i) => sortOrder.value[i]);
       }
     }
@@ -264,7 +264,6 @@ svg >>> .rowLabels {
   max-width: 20px;
   text-overflow: ellipsis;
   overflow: hidden;
-  font-size: 12pt;
   z-index: 100;
 }
 

--- a/src/components/IntermediaryNodes.vue
+++ b/src/components/IntermediaryNodes.vue
@@ -129,6 +129,7 @@ export default defineComponent({
 
     function buildIntView() {
       if (matrix.length > 0) {
+        const labelPadding = 10;
         const headerPadding = 5;
         const circleRadius = cellSize.value / 2;
         const cellFontSize = cellSize.value * 0.8;
@@ -200,11 +201,14 @@ export default defineComponent({
           .enter()
           .append('g')
           .attr('class', 'row')
-          .attr('transform', (_, i) => `translate(${matrixWidth.value / 5},${yScale.value(i)})`)
+          .attr('transform', (_, i) => `translate(0,${yScale.value(i)})`)
           .each(makeRow)
           .append('text')
           .attr('class', 'rowLabels')
+          .attr('x', -cellFontSize - labelPadding)
+          .attr('y', 5)
           .style('font-size', `${cellFontSize}px`)
+          .attr('dominant-baseline', 'hanging')
           .text((_, i) => sortOrder.value[i]);
       }
     }

--- a/src/components/IntermediaryNodes.vue
+++ b/src/components/IntermediaryNodes.vue
@@ -129,6 +129,8 @@ export default defineComponent({
 
     function buildIntView() {
       if (matrix.length > 0) {
+        const headerPadding = 5;
+        const circleRadius = cellSize.value / 2;
         const cellFontSize = cellSize.value * 0.8;
 
         const svg = select('#intNode').append('g').attr('transform', `translate(${margin.left},${margin.top})`);
@@ -138,18 +140,15 @@ export default defineComponent({
           .data([...Array(pathLength.value).keys()])
           .enter()
           .append('g')
-          .attr('transform', `translate(${matrixWidth.value / 7}, ${(margin.top - matrixHeight.value) / 4})`);
+          .attr('transform', (_, i) => `translate(${cellSize.value + xScale.value(i)}, ${(-circleRadius) - headerPadding})`);
 
         circles.append('circle')
           .attr('class', 'circleIcons')
-          .attr('cx', (_, i) => xScale.value(i))
-          .attr('cy', 0)
-          .attr('r', cellSize.value / 2)
+          .attr('r', circleRadius)
           .attr('fill', (_, i) => (i !== 0 && i !== (pathLength.value - 1) ? 'lightgrey' : 'none'));
 
         circles.append('text')
-          .attr('x', (_, i) => xScale.value(i))
-          .attr('y', cellSize.value / 2 - 3)
+          .attr('y', circleRadius / 2)
           .attr('text-anchor', 'middle')
           .attr('font-size', `${cellFontSize}px`)
           .text((_, i) => i + 1);

--- a/src/components/IntermediaryNodes.vue
+++ b/src/components/IntermediaryNodes.vue
@@ -102,10 +102,9 @@ export default defineComponent({
         .enter()
         .append('rect')
         .attr('class', 'connectivityCell')
-        .attr('x', (d) => yScale.value(d.x))
-        .attr('y', 1)
-        .attr('width', cellSize.value - 2)
-        .attr('height', cellSize.value - 2)
+        .attr('x', (_, i) => (i + 1.5) * cellSize.value)
+        .attr('width', cellSize.value)
+        .attr('height', cellSize.value)
         .style('fill-opacity', (d) => opacity(d.z))
         .style('fill', 'blue');
 
@@ -169,30 +168,26 @@ export default defineComponent({
         // vertical grid lines
         verticalLines
           .append('line')
-          .attr('x1', -yScale.value.range()[1])
+          .attr('x1', (_, i) => (i + 1.5) * cellSize.value)
+          .attr('x2', (_, i) => (i + 1.5) * cellSize.value)
           .attr('y1', 0)
-          .attr('y2', yScale.value.range()[1])
-          .attr('x1', (_, i) => xScale.value(i))
-          .attr('x2', (_, i) => xScale.value(i))
-          .attr('transform', `translate(${matrixWidth.value / 5 - 1},0)`);
+          .attr('y2', yScale.value.range()[1]);
 
         // horizontal grid lines
         horizontalLines
           .append('line')
-          .attr('x1', 0)
-          .attr('x2', xScale.value.range()[1] - 1)
+          .attr('x1', 1.5 * cellSize.value)
+          .attr('x2', 1.5 * cellSize.value + xScale.value.range()[1])
           .attr('y1', (_, i) => yScale.value(i))
-          .attr('y2', (_, i) => yScale.value(i))
-          .attr('transform', `translate(${matrixWidth.value / 5},0)`);
+          .attr('y2', (_, i) => yScale.value(i));
 
-        // horizontal grid line edges
+        // Add final horizontal grid line
         gridLines
           .append('line')
-          .attr('x1', 0)
-          .attr('x2', xScale.value.range()[1])
+          .attr('x1', 1.5 * cellSize.value)
+          .attr('x2', 1.5 * cellSize.value + xScale.value.range()[1])
           .attr('y1', yScale.value.range()[1])
-          .attr('y2', yScale.value.range()[1])
-          .attr('transform', `translate(${matrixWidth.value / 5},0)`);
+          .attr('y2', yScale.value.range()[1]);
 
         //   Draw rows
         svg

--- a/src/components/IntermediaryNodes.vue
+++ b/src/components/IntermediaryNodes.vue
@@ -34,7 +34,7 @@ export default defineComponent({
     });
 
     const margin = {
-      top: 79,
+      top: 110,
       right: 50,
       bottom: 0,
       left: 40,
@@ -42,7 +42,7 @@ export default defineComponent({
     const matrixHeight = computed(() => (connectivityPaths.value.nodes.length > 0 ? connectivityPaths.value.nodes.length * cellSize.value + margin.top + margin.bottom : 0));
 
     const intNodeWidth = computed(() => (store.state.connectivityMatrixPaths.nodes.length > 0
-      ? pathLength.value * cellSize.value + margin.left + margin.right
+      ? margin.left + (pathLength.value + 1) * cellSize.value
       : 0));
     const sortOrder = computed(() => store.state.connectivityMatrixPaths.nodes.map((node) => node._key).sort());
     const yScale = computed(() => scaleLinear().domain([0, sortOrder.value.length]).range([0, sortOrder.value.length * cellSize.value]));
@@ -201,6 +201,7 @@ export default defineComponent({
           .attr('y', 5)
           .style('font-size', `${cellFontSize}px`)
           .attr('dominant-baseline', 'hanging')
+          .attr('x', -20)
           .text((_, i) => sortOrder.value[i]);
       }
     }

--- a/src/components/IntermediaryNodes.vue
+++ b/src/components/IntermediaryNodes.vue
@@ -39,7 +39,6 @@ export default defineComponent({
       bottom: 0,
       left: 40,
     };
-    const matrixWidth = computed(() => (connectivityPaths.value.nodes.length > 0 ? edgeLength.value * cellSize.value + margin.left + margin.right : 0));
     const matrixHeight = computed(() => (connectivityPaths.value.nodes.length > 0 ? connectivityPaths.value.nodes.length * cellSize.value + margin.top + margin.bottom : 0));
 
     const intNodeWidth = computed(() => (store.state.connectivityMatrixPaths.nodes.length > 0
@@ -226,7 +225,6 @@ export default defineComponent({
     return {
       showTable,
       intNodeWidth,
-      matrixWidth,
       matrixHeight,
     };
   },
@@ -240,9 +238,9 @@ export default defineComponent({
   >
     <svg
       id="intNode"
-      :width="matrixWidth"
+      :width="intNodeWidth"
       :height="matrixHeight"
-      :viewbox="`0 0 ${matrixWidth} ${matrixHeight}`"
+      :viewbox="`0 0 ${intNodeWidth} ${matrixHeight}`"
     />
   </div>
 </template>

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -188,6 +188,7 @@ export default defineComponent({
 #lineup {
   z-index: 1;
   height: 10000px; /* big enough to show all rows */
+  padding-top: 34px;
 }
 
 .le-td {

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -37,7 +37,7 @@ export default defineComponent({
     const showPathTable = computed(() => store.state.showPathTable);
     const tooltip = ref(null);
     const visMargins = ref({
-      left: 75, top: 79, right: 0, bottom: 0,
+      left: 75, top: 110, right: 0, bottom: 0,
     });
     const matrix: Ref<Cell[][]> = ref([]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Closes #324

I refactored some of this logic to work with the changing cellSize. In so doing, I've simplified the logic slightly using translates where possible to remove the number of positioning steps. 

The new set up is 1 cell width for labels, 0.5 cell width of padding either side of the cells and then 1 cell width for each row of cells. This seems to work pretty well at the moment. We'll need to do some testing to make sure this generalizes well

I haven't been able to test this with the full size since the matrix becomes too large for my screen

New behavior for small cell size:
![image](https://user-images.githubusercontent.com/36867477/131394446-0d021465-392a-4dea-87d7-ebbf601be439.png)

New behavior for large cell size:
![image](https://user-images.githubusercontent.com/36867477/131394510-3d2c4731-9bb4-4dc2-8cba-4532ff0b589c.png)

TODO:
- [x] Some testing
- [x] The labels appear to get occluded when the cell size gets large enough. There must be some positioning causing problems