### PR TITLE
Make lineup re-render to adjust rowHeight based on cellSize

### DIFF
--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -13,6 +13,7 @@ export default defineComponent({
     const network = computed(() => store.state.network);
     const selectedNodes = computed(() => store.state.selectedNodes);
     const hoveredNodes = computed(() => store.state.hoveredNodes);
+    const cellSize = computed(() => store.state.cellSize);
 
     const lineup: Ref<LineUp | null> = ref(null);
     const builder: Ref<DataBuilder | null> = ref(null);
@@ -71,7 +72,7 @@ export default defineComponent({
         builder.value = new DataBuilder(network.value.nodes);
 
         // Config adjustments
-        builder.value.rowHeight(store.state.cellSize - 2, 2);
+        builder.value.rowHeight(cellSize.value - 2, 2);
 
         // Make the vis
         lineup.value = builder.value.deriveColumns(columns).deriveColors().defaultRanking().build(lineupDiv);
@@ -148,7 +149,7 @@ export default defineComponent({
       }
     });
 
-    watch(network, () => {
+    watch([network, cellSize], () => {
       removeLineup();
       buildLineup();
     });

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -72,7 +72,11 @@ export default defineComponent({
         builder.value = new DataBuilder(network.value.nodes);
 
         // Config adjustments
-        builder.value.rowHeight(cellSize.value - 2, 2);
+        builder.value.dynamicHeight(() => ({
+          defaultHeight: cellSize.value - 2,
+          padding: () => 2,
+          height: () => cellSize.value - 2,
+        }));
 
         // Make the vis
         lineup.value = builder.value.deriveColumns(columns).deriveColors().defaultRanking().build(lineupDiv);
@@ -149,9 +153,15 @@ export default defineComponent({
       }
     });
 
-    watch([network, cellSize], () => {
+    watch(network, () => {
       removeLineup();
       buildLineup();
+    });
+
+    watch(cellSize, () => {
+      if (lineup.value !== null) {
+        lineup.value.update();
+      }
     });
 
     function removeHighlight() {


### PR DESCRIPTION
Closes #323

This PR adds a watcher for cellSize in the lineup component that redraws the whole lineup componenet. This comes with significant performance issues.

My goal is to explore lineup's documentation + implementation to see if it's possible to update the `rowHeight` parameter without a full re-render.