### PR TITLE
Use the generalized linting workflow from the org .github repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,32 +1,14 @@
-name: CI
+name: Lint application using multinet-app/.github generic lint workflow
 
 on: 
   pull_request:
     branches:
-    - main
+      - '**'
   
   push:
     branches:
     - main
 
 jobs:
-  build-and-test:
-    name: Build and test on Ubuntu - Node 10
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '10.x'
-
-    - uses: actions/cache@v1
-      id: yarn-cache
-      with:
-        path: /home/runner/work/multimatrix/multimatrix/node_modules
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-cache
-
-    - name: Install yarn packages
-      if: steps.yarn-cache.outputs.cache-hit != 'true'
-      run: yarn install
-
-    - run: yarn lint
+  lint:
+    uses: multinet-app/.github/.github/workflows/lint.yaml@main


### PR DESCRIPTION
### Does this PR close any open issues?
Nope, it's just an improvement to help us reduce redundant code across the repos.

### Give a longer description of what this PR addresses and why it's needed
I've added an action in multinet-app/.github that handles this logic. The gameplan is to prefer using that to workflow files in each individual repo to provide more consistent testing.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] Make sure it works
- [x] Change the branch protection rules to make it use the new new for the workflow