### PR TITLE
Remove internal columns from lineup, except _key

### DIFF
--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -5,6 +5,7 @@ import {
 } from '@vue/composition-api';
 import LineUp, { DataBuilder } from 'lineupjs';
 import { select } from 'd3-selection';
+import { isInternalField } from '@/lib/typeUtils';
 
 export default defineComponent({
   name: 'LineUp',
@@ -67,7 +68,7 @@ export default defineComponent({
       const lineupDiv = document.getElementById('lineup');
 
       if (network.value !== null && lineupDiv !== null) {
-        const columns = [...new Set(network.value.nodes.map((node) => Object.keys(node)).flat())];
+        const columns = [...new Set(network.value.nodes.map((node) => Object.keys(node)).flat())].filter((column) => !isInternalField(column) || column === '_key');
 
         builder.value = new DataBuilder(network.value.nodes);
 


### PR DESCRIPTION
Depends on #356 

### Does this PR close any open issues?
Closes #358

### Give a longer description of what this PR addresses and why it's needed
This PR hides internal variables from lineup. I added back `_key`, since it's the default label variable, and I didn't want it to be confusing

### Provide pictures/videos of the behavior before and after these changes (optional)
Here's what remains on the les mis data set:
![image](https://user-images.githubusercontent.com/36867477/152253294-a72b8db0-d83f-40c3-b6a6-f30834eefbbe.png)


### Are there any additional TODOs before this PR is ready to go?
No