### PR TITLE
Collapse side panel on lineup first load

### DIFF
--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -80,7 +80,12 @@ export default defineComponent({
         }));
 
         // Make the vis
-        lineup.value = builder.value.deriveColumns(columns).deriveColors().defaultRanking().build(lineupDiv);
+        lineup.value = builder.value
+          .deriveColumns(columns)
+          .deriveColors()
+          .defaultRanking()
+          .sidePanel(true, true) // enable: true, collapsed: true
+          .build(lineupDiv);
 
         // Add an event watcher to update selected nodes
         lineup.value.on('selectionChanged', (dataindices: number[]) => {


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
Simply collapses the popover side panel on first load. See images below for the change.

Uses [this method](https://lineup.js.org/master/docs/classes/_builder_databuilder_.databuilder.html#sidepanel) from lineup.

### Provide pictures/videos of the behavior before and after these changes (optional)
Previous behavior:
![image](https://user-images.githubusercontent.com/36867477/152412257-da5c216b-9e6c-4c42-bfdf-1d1f4ae0ebb5.png)

New behavior:
![image](https://user-images.githubusercontent.com/36867477/152412299-a205e767-5869-46b5-98fd-fb0e57c9b6af.png)

### Are there any additional TODOs before this PR is ready to go?
No