### PR TITLE
Redesign the control panel to more closely match multilink

### DIFF
--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -224,7 +224,7 @@ export default defineComponent({
             if (selectedHops.value > 1) store.commit.toggleShowIntNodeVis(true);
 
             // Update state with new network
-            store.dispatch.aggregateNetwork('none');
+            store.dispatch.aggregateNetwork(undefined);
             store.dispatch.updateNetwork({ network: newNetwork });
             loading.value = false;
             store.commit.setDirectionalEdges(true);

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -21,7 +21,7 @@ export default defineComponent({
 
   setup() {
     // Template objects
-    const aggregateBy = ref('none');
+    const aggregateBy = ref(undefined);
     const directionalEdges = computed({
       get() {
         return store.state.directionalEdges;
@@ -74,7 +74,7 @@ export default defineComponent({
       get() {
         return store.state.intAggregatedBy;
       },
-      set(value: string) {
+      set(value: string | undefined) {
         store.commit.setIntAggregatedBy(value);
       },
     });
@@ -159,7 +159,7 @@ export default defineComponent({
     watchEffect(() => updateLegend(intTableColorScale.value, 'intTable'));
     watchEffect(() => {
       if (!aggregated.value) {
-        aggregateBy.value = 'none';
+        aggregateBy.value = undefined;
       }
     });
     watch(aggregated, () => {
@@ -171,7 +171,7 @@ export default defineComponent({
     });
     watchEffect(() => {
       if (!showIntNodeVis.value) {
-        intAggregatedBy.value = 'none';
+        intAggregatedBy.value = undefined;
       }
     });
 
@@ -407,9 +407,10 @@ export default defineComponent({
                 <v-autocomplete
                   v-model="intAggregatedBy"
                   class="pa-0 ma-0"
-                  :items="['none', ...nodeVariableItems]"
+                  :items="nodeVariableItems"
                   hint="Variable to aggregate by"
                   persistent-hint
+                  clearable
                 />
               </v-list-item-content>
             </v-list-item>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -21,6 +21,7 @@ export default defineComponent({
 
   setup() {
     // Template objects
+    const showMenu = ref(false);
     const aggregateBy = ref(undefined);
     const directionalEdges = computed({
       get() {
@@ -203,6 +204,7 @@ export default defineComponent({
       aggregateNetwork,
       labelVariable,
       multiVariableList,
+      showMenu,
     };
   },
 });
@@ -247,11 +249,33 @@ export default defineComponent({
       </v-toolbar>
 
       <v-list class="pa-0">
-        <v-subheader class="grey darken-3 py-0 white--text">
-          Controls
+        <v-subheader class="grey darken-3 py-0 pr-0 white--text">
+          Visualization Options
+
+          <v-spacer />
+
+          <v-btn
+            :min-width="40"
+            :height="48"
+            depressed
+            tile
+            class="grey darken-3 pa-0"
+            @click="showMenu = !showMenu"
+          >
+            <v-icon color="white">
+              mdi-cog
+            </v-icon>
+          </v-btn>
         </v-subheader>
 
-        <div class="pa-4">
+        <v-card
+          v-if="showMenu"
+          dark
+          tile
+          flat
+          color="grey darken-3"
+          class="pb-4 pt-0"
+        >
           <!-- Auto-Select Neighbors List Item -->
           <v-list-item class="px-0">
             <v-list-item-action class="mr-3">
@@ -355,7 +379,7 @@ export default defineComponent({
               Provenance Vis
             </v-btn>
           </v-list-item>
-        </div>
+        </v-card>
 
         <v-subheader class="grey darken-3 mt-6 py-0 white--text">
           Color Scale Legend

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -21,7 +21,6 @@ export default defineComponent({
 
   setup() {
     // Template objects
-    const connectivityQueryToggle = ref(false);
     const aggregateBy = ref('none');
     const directionalEdges = computed({
       get() {
@@ -185,7 +184,6 @@ export default defineComponent({
     }
 
     return {
-      connectivityQueryToggle,
       aggregateBy,
       directionalEdges,
       selectNeighbors,
@@ -288,18 +286,6 @@ export default defineComponent({
               />
             </v-list-item-action>
             <v-list-item-content> Directional Edges </v-list-item-content>
-          </v-list-item>
-
-          <!-- Connectivity Query List Item -->
-          <v-list-item class="px-0">
-            <v-list-item-action class="mr-3">
-              <v-switch
-                v-model="connectivityQueryToggle"
-                class="ma-0"
-                hide-details
-              />
-            </v-list-item-action>
-            <v-list-item-content> Enable Connectivity Query </v-list-item-content>
           </v-list-item>
 
           <v-list-item class="px-0">
@@ -445,7 +431,7 @@ export default defineComponent({
         </div>
 
         <!-- Connectivity Query -->
-        <div v-if="connectivityQueryToggle">
+        <div>
           <v-subheader class="grey darken-3 mt-6 py-0 white--text">
             Connectivity Query
           </v-subheader>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -369,10 +369,13 @@ export default defineComponent({
             style="display: flex; max-height: 50px"
           >
             Aggregate Legend
-            <svg id="parent-matrix-legend">
+            <svg
+              id="parent-matrix-legend"
+              height="50"
+            >
               <g
                 class="legendLinear"
-                transform="translate(10, 60)"
+                transform="translate(10, 10)"
               />
             </svg>
           </v-list-item>
@@ -383,10 +386,13 @@ export default defineComponent({
             :style="`display: flex; max-height: 50px; opacity: ${maxConnections.unAggr > 0 ? 1 : 0}`"
           >
             {{ aggregated ? 'Child Legend' : 'Matrix Legend' }}
-            <svg id="matrix-legend">
+            <svg
+              id="matrix-legend"
+              height="50"
+            >
               <g
                 class="legendLinear"
-                transform="translate(10, 60)"
+                transform="translate(10, 10)"
               />
             </svg>
           </v-list-item>
@@ -421,10 +427,13 @@ export default defineComponent({
               :style="`display: flex; max-height: 50px; opacity: ${maxIntConnections > 0 ? 1 : 0}`"
             >
               {{ 'Legend' }}
-              <svg id="int-matrix-legend">
+              <svg
+                id="int-matrix-legend"
+                height="50"
+              >
                 <g
                   class="legendLinear"
-                  transform="translate(10, 60)"
+                  transform="translate(10, 10)"
                 />
               </svg>
             </v-list-item>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -303,43 +303,42 @@ export default defineComponent({
           </v-list-item>
 
           <!-- Auto-Select Neighbors List Item -->
-          <v-list-item class="px-0">
-            <v-list-item-action class="mr-3">
+          <v-list-item>
+            <v-list-item-content> Autoselect Neighbors </v-list-item-content>
+            <v-list-item-action>
               <v-switch
                 v-model="selectNeighbors"
-                class="ma-0"
                 hide-details
+                color="blue darken-1"
               />
             </v-list-item-action>
-            <v-list-item-content> Autoselect Neighbors </v-list-item-content>
           </v-list-item>
 
           <!-- Gridline Toggle List Item -->
-          <v-list-item class="px-0">
-            <v-list-item-action class="mr-3">
+          <v-list-item>
+            <v-list-item-content> Show GridLines </v-list-item-content>
+            <v-list-item-action>
               <v-switch
                 v-model="showGridLines"
-                class="ma-0"
                 hide-details
+                color="blue darken-1"
               />
             </v-list-item-action>
-            <v-list-item-content> Show GridLines </v-list-item-content>
           </v-list-item>
 
           <!-- Directional Edges Toggle Card -->
-          <v-list-item class="px-0">
-            <v-list-item-action class="mr-3">
+          <v-list-item>
+            <v-list-item-content> Directional Edges </v-list-item-content>
+            <v-list-item-action>
               <v-switch
                 v-model="directionalEdges"
-                class="ma-0"
                 hide-details
+                color="blue darken-1"
               />
             </v-list-item-action>
-            <v-list-item-content> Directional Edges </v-list-item-content>
           </v-list-item>
 
-          <!-- Connectivity Query List Item -->
-          <v-list-item class="px-0">
+          <v-list-item>
             Cell Size
             <v-slider
               v-model="cellSize"
@@ -353,27 +352,25 @@ export default defineComponent({
             />
           </v-list-item>
 
-          <v-list-item class="px-0">
+          <v-list-item>
             <v-btn
-              block
-              class="ml-0 mt-4"
               color="primary"
-              depressed
-              @click="exportNetwork"
-            >
-              Export Network
-            </v-btn>
-          </v-list-item>
-
-          <v-list-item class="px-0">
-            <v-btn
               block
-              class="ml-0 mt-4"
-              color="primary"
               depressed
               @click="toggleProvVis"
             >
               Provenance Vis
+            </v-btn>
+          </v-list-item>
+
+          <v-list-item>
+            <v-btn
+              block
+              color="grey darken-2 white--text"
+              depressed
+              @click="exportNetwork"
+            >
+              Export Network
             </v-btn>
           </v-list-item>
         </v-card>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -276,6 +276,32 @@ export default defineComponent({
           color="grey darken-3"
           class="pb-4 pt-0"
         >
+          <v-list-item>
+            <v-autocomplete
+              v-model="labelVariable"
+              label="Label Variable"
+              :items="nodeVariableItems"
+              :hide-details="true"
+              class="mt-3"
+              clearable
+              outlined
+              dense
+            />
+          </v-list-item>
+          <v-list-item>
+            <v-autocomplete
+              v-model="aggregateBy"
+              label="Aggregation Variable"
+              :items="nodeVariableItems"
+              :hide-details="true"
+              class="mt-3"
+              clearable
+              outlined
+              dense
+              @change="aggregateNetwork"
+            />
+          </v-list-item>
+
           <!-- Auto-Select Neighbors List Item -->
           <v-list-item class="px-0">
             <v-list-item-action class="mr-3">
@@ -312,19 +338,6 @@ export default defineComponent({
             <v-list-item-content> Directional Edges </v-list-item-content>
           </v-list-item>
 
-          <v-list-item class="px-0">
-            <v-select
-              v-model="labelVariable"
-              label="Label Variable"
-              :items="Array.from(multiVariableList)"
-              :hide-details="true"
-              class="mt-2"
-              clearable
-              outlined
-              dense
-            />
-          </v-list-item>
-
           <!-- Connectivity Query List Item -->
           <v-list-item class="px-0">
             Cell Size
@@ -338,22 +351,6 @@ export default defineComponent({
               hide-details
               color="blue darken-1"
             />
-          </v-list-item>
-
-          <!-- Aggregation Variable Selection -->
-          <v-list-item
-            class="pa-0 ma-0"
-          >
-            <v-list-item-content class="pa-0 ma-0">
-              <v-autocomplete
-                v-model="aggregateBy"
-                class="pa-0 ma-0"
-                :items="['none', ...nodeVariableItems]"
-                hint="Variable to aggregate by"
-                persistent-hint
-                @change="aggregateNetwork"
-              />
-            </v-list-item-content>
           </v-list-item>
 
           <v-list-item class="px-0">

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -263,7 +263,7 @@ export default defineComponent({
             @click="showMenu = !showMenu"
           >
             <v-icon color="white">
-              mdi-cog
+              {{ showMenu ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
             </v-icon>
           </v-btn>
         </v-subheader>

--- a/src/components/IntermediaryNodes.vue
+++ b/src/components/IntermediaryNodes.vue
@@ -57,7 +57,7 @@ export default defineComponent({
         const hops = edgeLength.value - 1;
         matrix = [];
         let sortConnectivityPaths = [];
-        const sortKey = intAggregatedBy.value === 'none' ? '_key' : intAggregatedBy.value;
+        const sortKey = intAggregatedBy.value === undefined ? '_key' : intAggregatedBy.value;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         sortConnectivityPaths = connectivityPaths.value.nodes.sort((a: any, b: any) => (a[sortKey] > b[sortKey] ? 1 : -1));
 
@@ -101,7 +101,7 @@ export default defineComponent({
         ]);
 
         // Aggregate by label
-        if (intAggregatedBy.value !== 'none') {
+        if (intAggregatedBy.value !== undefined) {
           const newMatrix: ConnectivityCell[][] = [];
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const arrayColumn = (arr: any, n: number) => arr.map((x: any) => x[n]);

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -520,6 +520,7 @@ export default defineComponent({
       edges.value
         .selectAll('.colForeign')
         .attr('height', cellSize.value)
+        .select('p')
         .text((d: Node) => d[labelVariable.value || '_key']);
 
       edges.value
@@ -638,6 +639,7 @@ export default defineComponent({
       edges.value
         .selectAll('.rowForeign')
         .attr('height', cellSize.value)
+        .select('p')
         .text((d: Node) => d[labelVariable.value || '_key']);
 
       edges.value

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -66,7 +66,7 @@ const {
     selectedConnectivityPaths: [],
     showPathTable: false,
     maxIntConnections: 0,
-    intAggregatedBy: '',
+    intAggregatedBy: undefined,
     labelVariable: undefined,
   } as State,
 
@@ -289,7 +289,7 @@ const {
       state.maxIntConnections = maxIntConnections;
     },
 
-    setIntAggregatedBy(state, intAggregatedBy: string) {
+    setIntAggregatedBy(state, intAggregatedBy: string | undefined) {
       state.intAggregatedBy = intAggregatedBy;
     },
 
@@ -458,7 +458,7 @@ const {
       document.addEventListener('keydown', (event) => undoRedoKeyHandler(event, storeState));
     },
 
-    aggregateNetwork(context, varName: string) {
+    aggregateNetwork(context, varName: string | undefined) {
       const { state, commit, dispatch } = rootActionContext(context);
 
       if (state.network !== null) {
@@ -483,7 +483,7 @@ const {
         }
 
         // Aggregate the network if the varName is not none
-        if (varName !== 'none') {
+        if (varName !== undefined) {
           // Calculate edges
           const aggregatedEdges = state.network.edges.map((edge) => {
             const fromNode = state.network && state.network.nodes.find((node) => node._id === edge._from);

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,7 +94,7 @@ export interface State {
   selectedConnectivityPaths: ArangoPath[];
   showPathTable: boolean;
   maxIntConnections: number;
-  intAggregatedBy: string;
+  intAggregatedBy: string | undefined;
   labelVariable: string | undefined;
 }
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #357

### Give a longer description of what this PR addresses and why it's needed
Refactors the control menu to look more like multilink with the expanding card. I decided to simplify it down to one card, unlike on multilink, since Alex has been telling me that there isn't a clear reason why it's split up. 

On my path to this design, I also fixed some other issues:
- The legend SVGs were too large and overlapped with the `v-autocompletes`
- I made it so that the `aggregatedBy` could be cleared, allowing the resetting of the labels.
- I grouped controls that had visual styles together

### Provide pictures/videos of the behavior before and after these changes (optional)
Previous look:
![image](https://user-images.githubusercontent.com/36867477/152427094-3ba030b8-0de0-4580-a83f-9bfedd6e7c20.png)

Current collapsed look:
![image](https://user-images.githubusercontent.com/36867477/152428124-dde3d8bf-b97f-4ce7-934c-b6ca437657fc.png)

Current expanded look:
![image](https://user-images.githubusercontent.com/36867477/152428105-b65c6687-c286-4d43-ab94-5a22f96e5c51.png)


### Are there any additional TODOs before this PR is ready to go?

TODO:
- [x] Make an issue to add a search box (#363)