### PR TITLE
Add context menu to clear the selected nodes

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -1,0 +1,50 @@
+<script lang="ts">
+import store from '@/store';
+import {
+  computed, defineComponent,
+} from '@vue/composition-api';
+
+export default defineComponent({
+  setup() {
+    function clearSelection() {
+      store.commit.setSelected(new Set());
+    }
+
+    const rightClickMenu = computed(() => store.state.rightClickMenu);
+
+    return {
+      rightClickMenu,
+      clearSelection,
+    };
+  },
+});
+</script>
+
+<template>
+  <div
+    id="right-click-menu"
+  >
+    <v-menu
+      v-model="rightClickMenu.show"
+      :position-x="rightClickMenu.left"
+      :position-y="rightClickMenu.top"
+    >
+      <v-list>
+        <v-list-item
+          dense
+          @click="clearSelection"
+        >
+          <v-list-item-content>
+            <v-list-item-title>Clear Selection</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-menu>
+  </div>
+</template>
+
+<style>
+#right-click-menu {
+  position: absolute;
+}
+</style>

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -7,7 +7,7 @@ import {
 export default defineComponent({
   setup() {
     function clearSelection() {
-      store.commit.setSelected(new Set());
+      store.dispatch.clearSelection();
     }
 
     const rightClickMenu = computed(() => store.state.rightClickMenu);

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -16,6 +16,7 @@ import { transition } from 'd3-transition';
 import store from '@/store';
 import LineUp from '@/components/LineUp.vue';
 import IntermediaryNodes from '@/components/IntermediaryNodes.vue';
+import ContextMenu from '@/components/ContextMenu.vue';
 
 import 'science';
 import 'reorder.js';
@@ -32,6 +33,7 @@ export default defineComponent({
     LineUp,
     IntermediaryNodes,
     PathTable,
+    ContextMenu,
   },
 
   setup() {
@@ -187,6 +189,16 @@ export default defineComponent({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .transition(transition().delay(100).duration(200) as any)
         .style('opacity', 0);
+    }
+
+    function showContextMenu(event: MouseEvent) {
+      store.commit.updateRightClickMenu({
+        show: true,
+        top: event.y,
+        left: event.x,
+      });
+
+      event.preventDefault();
     }
 
     function sortObserver(type: string, isNode = false) {
@@ -933,6 +945,7 @@ export default defineComponent({
       matrixHeight,
       tooltip,
       showPathTable,
+      showContextMenu,
     };
   },
 
@@ -949,6 +962,7 @@ export default defineComponent({
           :width="matrixWidth"
           :height="matrixHeight"
           :viewbox="`0 0 ${matrixWidth} ${matrixHeight}`"
+          @contextmenu="showContextMenu"
         />
       </div>
       <intermediary-nodes v-if="finishedMounting && showIntNodeVis" />
@@ -960,6 +974,7 @@ export default defineComponent({
       ref="tooltip"
     />
     <path-table v-if="showPathTable" />
+    <context-menu />
   </div>
 </template>
 

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -13,7 +13,7 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
       provState.directionalEdges = newProvState.directionalEdges;
     } else if (label === 'Select Cell' || label === 'De-Select Cell') {
       provState.selectedCell = newProvState.selectedCell;
-    } else if (label === 'Select Node(s)' || label === 'De-select Node(s)') {
+    } else if (label === 'Select Node(s)' || label === 'De-select Node(s)' || label === 'Clear Selection') {
       provState.selectedNodes = newProvState.selectedNodes;
     } else if (label === 'Set Label Variable') {
       provState.labelVariable = newProvState.labelVariable;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -68,6 +68,11 @@ const {
     maxIntConnections: 0,
     intAggregatedBy: undefined,
     labelVariable: undefined,
+    rightClickMenu: {
+      show: false,
+      top: 0,
+      left: 0,
+    },
   } as State,
 
   getters: {
@@ -304,6 +309,20 @@ const {
 
       if (state.provenance !== null) {
         updateProvenanceState(state, 'Set Label Variable');
+      }
+    },
+
+    updateRightClickMenu(state, payload: { show: boolean; top: number; left: number }) {
+      state.rightClickMenu = payload;
+    },
+
+    setSelected(state, selectedNodes: Set<string>) {
+      state.selectedNodes = selectedNodes;
+
+      if (state.provenance !== null) {
+        if (selectedNodes.size === 0) {
+          updateProvenanceState(state, 'Clear Selection');
+        }
       }
     },
   },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -640,6 +640,15 @@ const {
         commit.removeSelectedNode(elementID);
       }
     },
+
+    clearSelection(context) {
+      const { state, commit } = rootActionContext(context);
+
+      commit.setSelected(new Set());
+      if (state.selectedCell !== null) {
+        commit.clickCell(state.selectedCell);
+      }
+    },
   },
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,11 @@ export interface State {
   maxIntConnections: number;
   intAggregatedBy: string | undefined;
   labelVariable: string | undefined;
+  rightClickMenu: {
+    show: boolean;
+    top: number;
+    left: number;
+  };
 }
 
 export type ProvenanceEventTypes =
@@ -106,6 +111,7 @@ export type ProvenanceEventTypes =
   'De-Select Cell' |
   'Select Node(s)' |
   'De-select Node(s)' |
+  'Clear Selection' |
   'Set Label Variable';
 
 export const internalFieldNames = ['_from', '_to', '_id', '_rev', '_key', 'neighbors', 'children'] as const;


### PR DESCRIPTION
Depends on #366 

### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
This adds a context menu when right clicking on the matrix that will clear the selected nodes. 

### Provide pictures/videos of the behavior before and after these changes (optional)
Context menu:
![image](https://user-images.githubusercontent.com/36867477/152592784-5adeabac-996e-48de-8511-78e3b120c2dc.png)

### Are there any additional TODOs before this PR is ready to go?
No