### PR TITLE
Only allow aggregating by category if column types are available

### DIFF
--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -57,7 +57,7 @@ export default defineComponent({
       networkOptions,
       workspace,
       workspaceOptions,
-      edgeTableName: computed(() => store.state.edgeTableName),
+      edgeTableName: computed(() => store.getters.edgeTableName),
     };
   },
 });

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -57,6 +57,7 @@ export default defineComponent({
       networkOptions,
       workspace,
       workspaceOptions,
+      edgeTableName: computed(() => store.state.edgeTableName),
     };
   },
 });
@@ -123,7 +124,7 @@ export default defineComponent({
     </v-alert>
 
     <filter-overlay
-      v-if="loadError.message === 'The network you are loading is too large'"
+      v-if="loadError.message === 'The network you are loading is too large' && edgeTableName !== null"
     />
   </div>
 </template>

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -163,7 +163,7 @@ export default defineComponent({
 
       const startNode = isTextComparison(selectedQueryOptions.value[0]) ? `UPPER(n.${selectedVariables.value[0]})` : `TO_NUMBER(n.${selectedVariables.value[0]})`;
       const aqlQuery = `
-        let startNodes = (FOR n in [${store.state.nodeTableNames}][**] FILTER ${startNode} ${selectedQueryOptions.value[0]} ${valueInQuery[0]} RETURN n)
+        let startNodes = (FOR n in [${store.getters.nodeTableNames}][**] FILTER ${startNode} ${selectedQueryOptions.value[0]} ${valueInQuery[0]} RETURN n)
         let paths = (FOR n IN startNodes FOR v, e, p IN 1..${selectedHops.value} ANY n GRAPH '${store.state.networkName}' ${pathQueryText} RETURN {paths: p})
         RETURN {paths: paths[**].paths}
       `;

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -66,6 +66,13 @@ export default defineComponent({
     const cellColorScale = computed(() => store.getters.cellColorScale);
     const parentColorScale = computed(() => store.getters.parentColorScale);
     const nodeVariableItems = computed(() => store.getters.nodeVariableItems);
+    const columnTypes = computed(() => store.state.columnTypes);
+    const aggregationItems = computed(() => store.getters.nodeVariableItems.filter((varName) => {
+      if (columnTypes.value !== null) {
+        return columnTypes.value[varName] === 'category';
+      }
+      return true;
+    }));
     const maxConnections = computed(() => store.state.maxConnections);
 
     // Intermediate node table template objects
@@ -203,6 +210,7 @@ export default defineComponent({
       cellColorScale,
       parentColorScale,
       nodeVariableItems,
+      aggregationItems,
       maxConnections,
       showIntNodeVis,
       intAggregatedBy,
@@ -304,7 +312,7 @@ export default defineComponent({
             <v-autocomplete
               v-model="aggregateBy"
               label="Aggregation Variable"
-              :items="nodeVariableItems"
+              :items="aggregationItems"
               :hide-details="true"
               class="mt-3"
               clearable

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -172,6 +172,9 @@ export default defineComponent({
         labelVariable.value = aggregateBy.value;
       }
     });
+    watch(aggregateBy, () => {
+      labelVariable.value = aggregateBy.value;
+    });
     watchEffect(() => {
       if (!showIntNodeVis.value) {
         intAggregatedBy.value = undefined;

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -66,13 +66,14 @@ export default defineComponent({
     const cellColorScale = computed(() => store.getters.cellColorScale);
     const parentColorScale = computed(() => store.getters.parentColorScale);
     const nodeVariableItems = computed(() => store.getters.nodeVariableItems);
-    const columnTypes = computed(() => store.state.columnTypes);
-    const aggregationItems = computed(() => store.getters.nodeVariableItems.filter((varName) => {
-      if (columnTypes.value !== null) {
-        return columnTypes.value[varName] === 'category';
-      }
-      return true;
-    }));
+    const aggregationItems = computed(() => {
+      // Rebuild column types but just for node columns
+      const nodeColumnTypes = store.state.columnTypes !== null ? Object.fromEntries(Object.entries(store.state.columnTypes).filter(([tableName]) => store.getters.nodeTableNames.includes(tableName))) : {};
+
+      // Get the varName of all node variables that are type category
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      return Object.values(nodeColumnTypes).map((colTypes) => Object.entries(colTypes).filter(([_, colType]) => colType === 'category').map(([varName, _]) => varName)).flat();
+    });
     const maxConnections = computed(() => store.state.maxConnections);
 
     // Intermediate node table template objects

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -168,8 +168,6 @@ export default defineComponent({
     watch(aggregated, () => {
       if (!aggregated.value) {
         labelVariable.value = '_key';
-      } else {
-        labelVariable.value = aggregateBy.value;
       }
     });
     watch(aggregateBy, () => {

--- a/src/components/FilterOverlay.vue
+++ b/src/components/FilterOverlay.vue
@@ -67,10 +67,10 @@ export default defineComponent({
 
     function getAttributes() {
       const aqlQuery = `
-      let nodeValues = (FOR doc IN ${store.state.nodeTableNames}[**] RETURN VALUES(doc))
-      let edgeValues = (FOR doc IN ${store.state.edgeTableName} RETURN VALUES(doc))
-      let nodeAttr = (FOR doc IN ${store.state.nodeTableNames}[**] LIMIT 1 RETURN doc)
-      let edgeAttr = (FOR doc IN ${store.state.edgeTableName} LIMIT 1 RETURN doc)
+      let nodeValues = (FOR doc IN ${store.getters.nodeTableNames}[**] RETURN VALUES(doc))
+      let edgeValues = (FOR doc IN ${store.getters.edgeTableName} RETURN VALUES(doc))
+      let nodeAttr = (FOR doc IN ${store.getters.nodeTableNames}[**] LIMIT 1 RETURN doc)
+      let edgeAttr = (FOR doc IN ${store.getters.edgeTableName} LIMIT 1 RETURN doc)
       RETURN {nodeAttributes: nodeAttr, nodeValues: nodeValues, edgeAttributes: edgeAttr, edgeValues: edgeValues}
       `;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -124,7 +124,7 @@ export default defineComponent({
         return;
       }
 
-      const aqlQuery = `let nodes = (FOR n in [${store.state.nodeTableNames}][**] LIMIT ${subsetAmount.value} RETURN n) let edges = (FOR e in ${store.state.edgeTableName} filter e._from in nodes[**]._id && e._to in nodes[**]._id RETURN e)
+      const aqlQuery = `let nodes = (FOR n in [${store.getters.nodeTableNames}][**] LIMIT ${subsetAmount.value} RETURN n) let edges = (FOR e in ${store.getters.edgeTableName} filter e._from in nodes[**]._id && e._to in nodes[**]._id RETURN e)
       RETURN {"nodes": nodes[**], edges}`;
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/FilterOverlay.vue
+++ b/src/components/FilterOverlay.vue
@@ -67,9 +67,9 @@ export default defineComponent({
 
     function getAttributes() {
       const aqlQuery = `
-      let nodeValues = (FOR doc IN ${store.getters.nodeTableNames}[**] RETURN VALUES(doc))
+      let nodeValues = (FOR doc IN [${store.getters.nodeTableNames}][**] RETURN VALUES(doc))
       let edgeValues = (FOR doc IN ${store.getters.edgeTableName} RETURN VALUES(doc))
-      let nodeAttr = (FOR doc IN ${store.getters.nodeTableNames}[**] LIMIT 1 RETURN doc)
+      let nodeAttr = (FOR doc IN [${store.getters.nodeTableNames}][**] LIMIT 1 RETURN doc)
       let edgeAttr = (FOR doc IN ${store.getters.edgeTableName} LIMIT 1 RETURN doc)
       RETURN {nodeAttributes: nodeAttr, nodeValues: nodeValues, edgeAttributes: edgeAttr, edgeValues: edgeValues}
       `;

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -533,7 +533,11 @@ export default defineComponent({
         .selectAll('.colForeign')
         .attr('height', cellSize.value)
         .select('p')
-        .text((d: Node) => d[labelVariable.value || '_key']);
+        .text((d: Node) => {
+          if (d.type === 'supernode') {
+            return d._key;
+          } return d[labelVariable.value || '_key'];
+        });
 
       edges.value
         .selectAll('.colForeign')
@@ -579,7 +583,11 @@ export default defineComponent({
         .attr('width', labelWidth)
         .attr('height', cellSize.value)
         .append('xhtml:p')
-        .text((d: Node) => d[labelVariable.value || '_key'])
+        .text((d: Node) => {
+          if (d.type === 'supernode') {
+            return d._key;
+          } return d[labelVariable.value || '_key'];
+        })
         .style('color', (d: Node) => {
           if (d.type === 'node') {
             return '#aaa';
@@ -652,7 +660,11 @@ export default defineComponent({
         .selectAll('.rowForeign')
         .attr('height', cellSize.value)
         .select('p')
-        .text((d: Node) => d[labelVariable.value || '_key']);
+        .text((d: Node) => {
+          if (d.type === 'supernode') {
+            return d._key;
+          } return d[labelVariable.value || '_key'];
+        });
 
       edges.value
         .selectAll('.rowForeign')
@@ -692,7 +704,11 @@ export default defineComponent({
         .attr('height', cellSize.value)
         .classed('rowForeign', true)
         .append('xhtml:p')
-        .text((d: Node) => d[labelVariable.value || '_key'])
+        .text((d: Node) => {
+          if (d.type === 'supernode') {
+            return d._key;
+          } return d[labelVariable.value || '_key'];
+        })
         .style('color', (d: Node) => {
           if (d.type === 'node') {
             return '#aaa';

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -536,7 +536,8 @@ export default defineComponent({
         .text((d: Node) => {
           if (d.type === 'supernode') {
             return d._key;
-          } return d[labelVariable.value || '_key'];
+          }
+          return d[labelVariable.value || '_key'];
         });
 
       edges.value
@@ -586,7 +587,8 @@ export default defineComponent({
         .text((d: Node) => {
           if (d.type === 'supernode') {
             return d._key;
-          } return d[labelVariable.value || '_key'];
+          }
+          return d[labelVariable.value || '_key'];
         })
         .style('color', (d: Node) => {
           if (d.type === 'node') {
@@ -663,7 +665,8 @@ export default defineComponent({
         .text((d: Node) => {
           if (d.type === 'supernode') {
             return d._key;
-          } return d[labelVariable.value || '_key'];
+          }
+          return d[labelVariable.value || '_key'];
         });
 
       edges.value
@@ -707,7 +710,8 @@ export default defineComponent({
         .text((d: Node) => {
           if (d.type === 'supernode') {
             return d._key;
-          } return d[labelVariable.value || '_key'];
+          }
+          return d[labelVariable.value || '_key'];
         })
         .style('color', (d: Node) => {
           if (d.type === 'node') {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -97,6 +97,9 @@ const {
     },
 
     nodeVariableItems(state): string[] {
+      if (state.network !== null && state.columnTypes !== null && Object.keys(state.columnTypes).length > 0) {
+        return Object.keys(state.columnTypes).filter((varName) => !isInternalField(varName));
+      }
       if (state.network !== null) {
         return Object.keys(state.nodeAttributes).filter((varName) => !isInternalField(varName));
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { TableRow, UserSpec } from 'multinet';
+import { ColumnTypes, TableRow, UserSpec } from 'multinet';
 import { Provenance } from '@visdesignlab/trrack';
 
 export interface Dimensions {
@@ -95,6 +95,7 @@ export interface State {
   showPathTable: boolean;
   maxIntConnections: number;
   intAggregatedBy: string | undefined;
+  columnTypes: ColumnTypes | null;
   labelVariable: string | undefined;
   rightClickMenu: {
     show: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,6 @@
-import { ColumnTypes, TableRow, UserSpec } from 'multinet';
+import {
+  ColumnTypes, Table, TableRow, UserSpec,
+} from 'multinet';
 import { Provenance } from '@visdesignlab/trrack';
 
 export interface Dimensions {
@@ -83,8 +85,6 @@ export interface State {
     unAggr: number;
     parent: number;
   };
-  nodeTableNames: string[];
-  edgeTableName: string | null;
   provenance: Provenance<State, ProvenanceEventTypes, unknown> | null;
   showProvenanceVis: boolean;
   nodeAttributes: ArangoAttributes;
@@ -95,7 +95,8 @@ export interface State {
   showPathTable: boolean;
   maxIntConnections: number;
   intAggregatedBy: string | undefined;
-  columnTypes: ColumnTypes | null;
+  networkTables: Table[];
+  columnTypes: { [tableName: string]: ColumnTypes } | null;
   labelVariable: string | undefined;
   rightClickMenu: {
     show: boolean;


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #360 (thanks @gotdairyya)
Closes #376

### Give a longer description of what this PR addresses and why it's needed
This PR restricts the columns we can aggregate by if we have type information from the API. If the type data is null, it will show all columns as before.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] Test how this works with marclab data
- [x] See if empty metadata comes back as null or `{}` (every table must be uploaded with metadata)