### PR TITLE
Make querying more robust

### DIFF
--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -43,7 +43,7 @@
         <!-- All of the query options -->
         <v-list dense>
           <v-list-item
-            v-for="(val, j) in inputs.value[0]"
+            v-for="(val, j) in inputs.value"
             :key="`val-${i}-${j}`"
             class="pa-0"
           >
@@ -143,6 +143,7 @@
             </v-list-item>
           </v-list-item>
         </v-list>
+
         <!-- Let user query for another edge -->
         <v-card-actions v-if="i === 1">
           <v-btn
@@ -171,7 +172,7 @@
           <div v-show="showSecondEdge && i === 1">
             <v-list dense>
               <v-list-item
-                v-for="(val, k) in inputs.value[i]"
+                v-for="(val, k) in edgeMutexs.value"
                 :key="`val-${i}-2-${k}`"
                 class="pa-0"
               >
@@ -184,7 +185,7 @@
                       class="pt-3"
                     >
                       <v-autocomplete
-                        v-model="inputs.operator"
+                        v-model="edgeMutexs.operator"
                         :items="operatorOptionItems"
                         dense
                       />
@@ -331,80 +332,47 @@ export default defineComponent({
     });
 
     // Create the object for storing input data
-    const queryInput: Ref<{ key: number; value: { label: string; operator: string; input: string }[][]; operator: string }[]> = ref([]);
+    const queryInput: Ref<{ key: number; value: { label: string; operator: string; input: string }[]; operator: string }[]> = ref([]);
+    const edgeMutexs: Ref<{ value: { label: string; operator: string; input: string }[]; operator: string }> = ref({ value: [], operator: '' });
 
-    watch([displayedHops], () => {
+    function resetDefaultValues() {
       queryInput.value = [...Array(displayedHops.value).keys()].map((i: number) => {
         if (store.state.workspaceName === 'marclab') {
-          if (i === 1) {
-            return {
-              key: i, value: [[{ label: 'Label', operator: '=~', input: '' }], [{ label: 'Label', operator: '=~', input: '' }]], operator: '',
-            };
-          }
           if (i % 2) {
             return {
-              key: i, value: [[{ label: 'Type', operator: '=~', input: '' }], []], operator: '',
+              key: i, value: [{ label: 'Type', operator: '=~', input: '' }], operator: '',
             };
           }
           return {
-            key: i, value: [[{ label: 'Label', operator: '=~', input: '' }], []], operator: '',
-          };
-        }
-
-        if (i === 1) {
-          return {
-            key: i, value: [[{ label: '', operator: '=~', input: '' }], [{ label: '', operator: '=~', input: '' }]], operator: '',
+            key: i, value: [{ label: 'Label', operator: '=~', input: '' }], operator: '',
           };
         }
         return {
-          key: i, value: [[{ label: '', operator: '=~', input: '' }], []], operator: '',
+          key: i, value: [{ label: '', operator: '=~', input: '' }], operator: '',
         };
       });
-    });
 
-    onMounted(() => {
-      queryInput.value = [...Array(displayedHops.value).keys()].map((i: number) => {
-        if (store.state.workspaceName === 'marclab') {
-          if (i === 1) {
-            return {
-              key: i, value: [[{ label: 'Label', operator: '=~', input: '' }], [{ label: 'Label', operator: '=~', input: '' }]], operator: '',
-            };
-          }
-          if (i % 2) {
-            return {
-              key: i, value: [[{ label: 'Type', operator: '=~', input: '' }], []], operator: '',
-            };
-          }
-          return {
-            key: i, value: [[{ label: 'Label', operator: '=~', input: '' }], []], operator: '',
-          };
-        }
-
-        if (i === 1) {
-          return {
-            key: i, value: [[{ label: '', operator: '=~', input: '' }], [{ label: '', operator: '=~', input: '' }]], operator: '',
-          };
-        }
-        return {
-          key: i, value: [[{ label: '', operator: '=~', input: '' }], []], operator: '',
+      if (store.state.workspaceName === 'marclab') {
+        edgeMutexs.value = {
+          value: [{ label: 'Type', operator: '=~', input: '' }], operator: '',
         };
-      });
-    });
-
-    function addField(index: number, secondEdgeQuery: boolean) {
-      if (secondEdgeQuery) {
-        queryInput.value[index].value[1].push({ input: '', label: '', operator: '=~' });
       } else {
-        queryInput.value[index].value[0].push({ input: '', label: '', operator: '=~' });
+        edgeMutexs.value = {
+          value: [{ label: '', operator: '=~', input: '' }], operator: '',
+        };
       }
     }
 
-    function removeField(index: number, field: number, secondEdgeQuery: boolean) {
-      if (secondEdgeQuery) {
-        queryInput.value[index].value[1].splice(field, 1);
-      } else {
-        queryInput.value[index].value[0].splice(field, 1);
-      }
+    watch([displayedHops], () => resetDefaultValues());
+
+    onMounted(() => resetDefaultValues());
+
+    function addField(index: number) {
+      queryInput.value[index].value.push({ input: '', label: '', operator: '=~' });
+    }
+
+    function removeField(index: number, field: number) {
+      queryInput.value[index].value.splice(field, 1);
     }
 
     function isTextComparison(operator: string) {
@@ -574,6 +542,7 @@ export default defineComponent({
       removeField,
       queryInput,
       operatorOptionItems,
+      edgeMutexs,
     };
   },
 });

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -211,17 +211,17 @@ export default defineComponent({
     });
 
     // Create the object for storing input data
-    const queryInput: Ref<{ key: number; value: { label: string; operator: string; input: string }[]; logic: string }[]> = ref([{ key: 1, value: [{ label: '', operator: '', input: '' }], logic: '' }]);
+    const queryInput: Ref<{ key: number; value: { label: string; operator: string; input: string }[]; operator: string }[]> = ref([]);
 
     watch([displayedHops], () => {
       queryInput.value = [...Array(displayedHops.value).keys()].map((i: number) => {
         if (i % 2 && store.state.workspaceName === 'marclab') {
           return {
-            key: i, value: [{ label: 'Type', operator: '', input: '' }], logic: '',
+            key: i, value: [{ label: 'Type', operator: '=~', input: '' }], operator: '',
           };
         }
         return {
-          key: i, value: [{ label: 'Label', operator: '', input: '' }], logic: '',
+          key: i, value: [{ label: '', operator: '=~', input: '' }], operator: '',
         };
       });
     });
@@ -230,23 +230,17 @@ export default defineComponent({
       queryInput.value = [...Array(displayedHops.value).keys()].map((i: number) => {
         if (i % 2 && store.state.workspaceName === 'marclab') {
           return {
-            key: i, value: [{ label: 'Type', operator: '', input: '' }], logic: '',
+            key: i, value: [{ label: 'Type', operator: '=~', input: '' }], operator: '',
           };
         }
         return {
-          key: i, value: [{ label: 'Label', operator: '', input: '' }], logic: '',
+          key: i, value: [{ label: '', operator: '=~', input: '' }], operator: '',
         };
       });
     });
 
-    // 7 = 2n + 1 for n = 3 (max number of hops allowed above)
-    Array(7).fill(1).forEach(() => {
-      selectedVariables.value.push(store.state.workspaceName === 'marclab' ? 'Label' : '');
-      selectedQueryOptions.value.push('=~');
-    });
-
     function addField(index: number) {
-      queryInput.value[index].value.push({ input: '', label: '', operator: 'AND' });
+      queryInput.value[index].value.push({ input: '', label: '', operator: '=~' });
     }
 
     function removeField(index: number, field: number) {

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -23,7 +23,7 @@
             v-on="on"
           >
             <v-icon>
-              mdi-arrow-right
+              mdi-cog
             </v-icon>
           </v-btn>
         </template>
@@ -141,27 +141,23 @@
             <!-- Let user query for another edge -->
             <v-list-item v-if="i === 1">
               <v-row>
-                <v-col
-                  class=""
-                >
-                  {{ showSecondEdge ? 'No other path with' : '' }}
+                <v-col>
+                  <v-list-item-title>
+                    {{ showSecondEdge ? 'NO OTHER PATH WITH' : '' }}
+                  </v-list-item-title>
                 </v-col>
-
-                <v-spacer />
-                <v-tooltip right>
-                  <template v-slot:activator="{ on, attrs }">
-                    <v-btn
-                      icon
-                      color="orange lighten-2"
-                      v-bind="attrs"
-                      @click="showSecondEdge = !showSecondEdge"
-                      v-on="on"
-                    >
-                      <v-icon>{{ showSecondEdge ? 'mdi-minus' : 'mdi-plus' }}</v-icon>
-                    </v-btn>
-                  </template>
-                  <span>{{ showSecondEdge ? 'Remove edge' : 'Add new edge' }}</span>
-                </v-tooltip>
+                <v-btn
+                  v-bind="attrs"
+                  class="mb-2"
+                  depressed
+                  @click="showSecondEdge = !showSecondEdge"
+                  v-on="on"
+                >
+                  {{ showSecondEdge ? 'Remove second edge query' : 'Add second edge query' }}
+                  <v-icon right>
+                    {{ showSecondEdge ? 'mdi-minus' : 'mdi-plus' }}
+                  </v-icon>
+                </v-btn>
               </v-row>
             </v-list-item>
             <v-expand-transition>

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -349,9 +349,14 @@ export default defineComponent({
             // Update state with new network
             store.dispatch.aggregateNetwork(undefined);
             store.dispatch.updateNetwork({ network: newNetwork });
-            loading.value = false;
-            store.commit.setDirectionalEdges(true);
+          } else {
+            // Update state with empty network
+            store.dispatch.aggregateNetwork(undefined);
+            store.dispatch.updateNetwork({ network: { nodes: [], edges: [] } });
+            store.commit.toggleShowIntNodeVis(false);
           }
+
+          loading.value = false;
         });
       }
     }

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -269,9 +269,10 @@ export default defineComponent({
         // Loop through each query piece
         input.value.forEach((queryPiece, index) => {
           // Add the right operator (AND for edge then node else, whatever op is defined)
-          const operator = input.operator === 'NOT' ? 'OR' : input.operator;
+          const operator = input.operator === 'NOT' ? 'AND NOT (' : input.operator;
+
           if (index === 0) {
-            currentString += input.operator === 'NOT' ? 'AND NOT ( ' : 'AND ( ';
+            currentString += 'AND ( ';
           } else {
             currentString += `${operator} `;
           }
@@ -284,6 +285,10 @@ export default defineComponent({
             property = isTextComparison(queryPiece.operator) ? `UPPER(${property})` : `TO_NUMBER(${property})`;
             const value = isTextComparison(queryPiece.operator) ? `UPPER('${queryPiece.input}')` : `TO_NUMBER(${queryPiece.input})`;
             currentString += `${property} ${queryPiece.operator} ${value} `;
+          }
+
+          if (index !== 0 && input.operator === 'NOT') {
+            currentString += ')';
           }
         });
         currentString += ') ';

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -195,8 +195,6 @@ export default defineComponent({
     const queryOptionItems = ['==', '=~', '!=', '<', '<=', '>', '>='];
     const operatorOptionItems = ['AND', 'OR', 'NOT'];
 
-    const selectedVariableValue: Ref<string[]> = ref([]);
-
     const variableValueItems = computed(() => {
       const variableItems = { node: [], edge: [] };
       if (store.state.network !== null) {
@@ -382,7 +380,6 @@ export default defineComponent({
       queryOptionItems,
       selectedVariables,
       selectedQueryOptions,
-      selectedVariableValue,
       nodeVariableItems,
       edgeVariableItems,
       variableValueItems,

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -196,9 +196,9 @@ export default defineComponent({
     const operatorOptionItems = ['AND', 'OR', 'NOT'];
 
     const variableValueItems = computed(() => {
-      const variableItems = { node: [], edge: [] };
+      const variableItems: { node: { [key: string]: string[] }; edge: { [key: string]: string[] } } = { node: {}, edge: {} };
       if (store.state.network !== null) {
-        nodeVariableItems.value.forEach((nodeVariable: string) => {
+        nodeVariableItems.value.forEach((nodeVariable) => {
           variableItems.node[nodeVariable] = store.state.nodeAttributes[nodeVariable].map((value) => `${value}`);
         });
         edgeVariableItems.value.forEach((edgeVariable: string) => {

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -433,7 +433,7 @@ export default defineComponent({
         if (input.key === 0) {
           // Add mutual exclusion query line
           if (showSecondEdge.value) {
-            currentString += `RETURN n0) \nLET excluded_nodes = UNIQUE(FOR n0 in start_nodes FOR n1, e1, p1 IN 1..1 ANY n0 GRAPH '${store.state.networkName}' FILTER (`;
+            currentString += `RETURN n0) \nLET excluded_pairs = UNIQUE(FOR n0 in start_nodes FOR n1, e1, p1 IN 1..1 ANY n0 GRAPH '${store.state.networkName}' FILTER (`;
 
             // Add mutual exclusion filters
             const { operator } = edgeMutexs.value;

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -424,11 +424,16 @@ export default defineComponent({
         });
         currentString += ') ';
 
+        // Add to the filter for edge mutex
+        if (input.key === 1) {
+          currentString += 'AND (NOT POSITION(excluded_pairs, [n0, n1]))';
+        }
+
         // Append any last required string
         if (input.key === 0) {
           // Add mutual exclusion query line
           if (showSecondEdge.value) {
-            currentString += `RETURN n0) \nLET excluded_nodes = (FOR n0 in start_nodes FOR n1, e1, p1 IN 1..1 ANY n0 GRAPH '${store.state.networkName}' FILTER (`;
+            currentString += `RETURN n0) \nLET excluded_nodes = UNIQUE(FOR n0 in start_nodes FOR n1, e1, p1 IN 1..1 ANY n0 GRAPH '${store.state.networkName}' FILTER (`;
 
             // Add mutual exclusion filters
             const { operator } = edgeMutexs.value;
@@ -443,7 +448,7 @@ export default defineComponent({
             // Add filter ending parenthesis
             currentString += ') ';
 
-            currentString += 'RETURN p1)[**].vertices[0] \nFOR n0 in MINUS(start_nodes, excluded_nodes)';
+            currentString += 'RETURN p1.vertices) \nFOR n0 in start_nodes';
           } else {
             currentString += 'RETURN n0) \nFOR n0 in start_nodes';
           }

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="pa-0">
     <v-card
-      color="grey lighten-3"
+      color="grey darken-2"
       flat
       tile
     >

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -151,7 +151,6 @@
                   </v-list-item-title>
                 </v-col>
                 <v-btn
-                  v-bind="attrs"
                   class="mb-2"
                   depressed
                   @click="showSecondEdge = !showSecondEdge"

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -269,7 +269,12 @@ export default defineComponent({
         // Loop through each query piece
         input.value.forEach((queryPiece, index) => {
           // Add the right operator (AND for edge then node else, whatever op is defined)
-          currentString += `${index === 0 ? 'AND (' : input.operator} `;
+          const operator = input.operator === 'NOT' ? 'OR' : input.operator;
+          if (index === 0) {
+            currentString += input.operator === 'NOT' ? 'AND NOT ( ' : 'AND ( ';
+          } else {
+            currentString += `${operator} `;
+          }
 
           // If no filter, do nothing
           if (queryPiece.label === '') {

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -272,7 +272,9 @@ export default defineComponent({
           currentString += `${index === 0 ? 'AND (' : input.operator} `;
 
           // If no filter, do nothing
-          if (queryPiece.label !== '') {
+          if (queryPiece.label === '') {
+            currentString += '1==1 ';
+          } else {
             let property = thisRoundIsNode ? `n${nodeOrEdgeNum}.${queryPiece.label}` : `e${nodeOrEdgeNum + 1}.${queryPiece.label}`;
             property = isTextComparison(queryPiece.operator) ? `UPPER(${property})` : `TO_NUMBER(${property})`;
             const value = isTextComparison(queryPiece.operator) ? `UPPER('${queryPiece.input}')` : `TO_NUMBER(${queryPiece.input})`;

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -40,9 +40,10 @@
         color="white"
         class="p-0"
       >
+        <!-- All of the query options -->
         <v-list dense>
           <v-list-item
-            v-for="(val, j) in inputs.value"
+            v-for="(val, j) in inputs.value[0]"
             :key="`val-${i}-${j}`"
             class="pa-0"
           >
@@ -142,6 +143,128 @@
             </v-list-item>
           </v-list-item>
         </v-list>
+        <!-- Let user query for another edge -->
+        <v-card-actions v-if="i === 1">
+          <v-btn
+            text
+          >
+            {{ showSecondEdge ? 'No other path with' : '' }}
+          </v-btn>
+
+          <v-spacer />
+          <v-tooltip right>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn
+                icon
+                color="orange lighten-2"
+                v-bind="attrs"
+                @click="showSecondEdge = !showSecondEdge"
+                v-on="on"
+              >
+                <v-icon>{{ showSecondEdge ? 'mdi-minus' : 'mdi-plus' }}</v-icon>
+              </v-btn>
+            </template>
+            <span>{{ showSecondEdge ? 'Remove edge' : 'Add new edge' }}</span>
+          </v-tooltip>
+        </v-card-actions>
+        <v-expand-transition>
+          <div v-show="showSecondEdge && i === 1">
+            <v-list dense>
+              <v-list-item
+                v-for="(val, k) in inputs.value[i]"
+                :key="`val-${i}-2-${k}`"
+                class="pa-0"
+              >
+                <v-list-item class="pa-0">
+                  <v-row no-gutters>
+                    <v-col
+                      v-if="k > 0"
+                      cols="12"
+                      sm="2"
+                      class="pt-3"
+                    >
+                      <v-autocomplete
+                        v-model="inputs.operator"
+                        :items="operatorOptionItems"
+                        dense
+                      />
+                    </v-col>
+                    <v-list-item-content class="pa-0 pr-1">
+                      <v-col
+                        cols="12"
+                        sm="3"
+                        class="pa-1"
+                      >
+                        <v-autocomplete
+                          v-model="val.label"
+                          :items="edgeVariableItems"
+                          dense
+                        />
+                      </v-col>
+                      <v-col
+                        cols="12"
+                        sm="3"
+                        class="pa-1"
+                      >
+                        <v-autocomplete
+                          v-model="val.operator"
+                          :items="queryOptionItems"
+                          dense
+                        />
+                      </v-col>
+                      <v-col
+                        cols="12"
+                        sm="3"
+                        class="pa-1"
+                      >
+                        <v-autocomplete
+                          v-if="val.operator === '=='"
+                          v-model="val.input"
+                          :items="edgeAttributeItems[val.label]"
+                          dense
+                        />
+                        <v-text-field
+                          v-else
+                          v-model="val.input"
+                          dense
+                        />
+                      </v-col>
+                      <v-col
+                        cols="12"
+                        sm="1"
+                        class="mt-3"
+                      >
+                        <!-- Add button -->
+                        <v-btn
+                          icon
+                          x-small
+                          color="primary"
+                          @click="addField(i, true)"
+                        >
+                          <v-icon>
+                            mdi-plus
+                          </v-icon>
+                        </v-btn>
+                        <!-- Remove button -->
+                        <v-btn
+                          v-show="k > 0"
+                          icon
+                          x-small
+                          color="red"
+                          @click="removeField(i, k, true)"
+                        >
+                          <v-icon>
+                            mdi-minus
+                          </v-icon>
+                        </v-btn>
+                      </v-col>
+                    </v-list-item-content>
+                  </v-row>
+                </v-list-item>
+              </v-list-item>
+            </v-list>
+          </div>
+        </v-expand-transition>
       </v-card>
 
       <v-list-item>
@@ -175,6 +298,7 @@ export default defineComponent({
 
   setup() {
     const showMenu = ref(false);
+    const showSecondEdge = ref(false);
     const hopsSelection = [1, 2, 3];
     const selectedHops = computed({
       get() {
@@ -207,40 +331,80 @@ export default defineComponent({
     });
 
     // Create the object for storing input data
-    const queryInput: Ref<{ key: number; value: { label: string; operator: string; input: string }[]; operator: string }[]> = ref([]);
+    const queryInput: Ref<{ key: number; value: { label: string; operator: string; input: string }[][]; operator: string }[]> = ref([]);
 
     watch([displayedHops], () => {
       queryInput.value = [...Array(displayedHops.value).keys()].map((i: number) => {
-        if (i % 2 && store.state.workspaceName === 'marclab') {
+        if (store.state.workspaceName === 'marclab') {
+          if (i === 1) {
+            return {
+              key: i, value: [[{ label: 'Label', operator: '=~', input: '' }], [{ label: 'Label', operator: '=~', input: '' }]], operator: '',
+            };
+          }
+          if (i % 2) {
+            return {
+              key: i, value: [[{ label: 'Type', operator: '=~', input: '' }], []], operator: '',
+            };
+          }
           return {
-            key: i, value: [{ label: 'Type', operator: '=~', input: '' }], operator: '',
+            key: i, value: [[{ label: 'Label', operator: '=~', input: '' }], []], operator: '',
+          };
+        }
+
+        if (i === 1) {
+          return {
+            key: i, value: [[{ label: '', operator: '=~', input: '' }], [{ label: '', operator: '=~', input: '' }]], operator: '',
           };
         }
         return {
-          key: i, value: [{ label: 'Label', operator: '=~', input: '' }], operator: '',
+          key: i, value: [[{ label: '', operator: '=~', input: '' }], []], operator: '',
         };
       });
     });
 
     onMounted(() => {
       queryInput.value = [...Array(displayedHops.value).keys()].map((i: number) => {
-        if (i % 2 && store.state.workspaceName === 'marclab') {
+        if (store.state.workspaceName === 'marclab') {
+          if (i === 1) {
+            return {
+              key: i, value: [[{ label: 'Label', operator: '=~', input: '' }], [{ label: 'Label', operator: '=~', input: '' }]], operator: '',
+            };
+          }
+          if (i % 2) {
+            return {
+              key: i, value: [[{ label: 'Type', operator: '=~', input: '' }], []], operator: '',
+            };
+          }
           return {
-            key: i, value: [{ label: 'Type', operator: '=~', input: '' }], operator: '',
+            key: i, value: [[{ label: 'Label', operator: '=~', input: '' }], []], operator: '',
+          };
+        }
+
+        if (i === 1) {
+          return {
+            key: i, value: [[{ label: '', operator: '=~', input: '' }], [{ label: '', operator: '=~', input: '' }]], operator: '',
           };
         }
         return {
-          key: i, value: [{ label: 'Label', operator: '=~', input: '' }], operator: '',
+          key: i, value: [[{ label: '', operator: '=~', input: '' }], []], operator: '',
         };
       });
     });
 
-    function addField(index: number) {
-      queryInput.value[index].value.push({ input: '', label: '', operator: '=~' });
+    function addField(index: number, secondEdgeQuery: boolean) {
+      if (secondEdgeQuery) {
+        queryInput.value[index].value[1].push({ input: '', label: '', operator: '=~' });
+      } else {
+        queryInput.value[index].value[0].push({ input: '', label: '', operator: '=~' });
+      }
     }
 
-    function removeField(index: number, field: number) {
-      queryInput.value[index].value.splice(field, 1);
+    function removeField(index: number, field: number, secondEdgeQuery: boolean) {
+      if (secondEdgeQuery) {
+        queryInput.value[index].value[1].splice(field, 1);
+      } else {
+        queryInput.value[index].value[0].splice(field, 1);
+      }
     }
 
     function isTextComparison(operator: string) {
@@ -393,6 +557,7 @@ export default defineComponent({
     }
     return {
       showMenu,
+      showSecondEdge,
       hopsSelection,
       selectedHops,
       displayedHops,

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -7,7 +7,7 @@
 
       <v-dialog
         v-model="dialog"
-        max-width="600px"
+        width="780px"
       >
         <template v-slot:activator="{ on, attrs }">
           <v-btn
@@ -53,44 +53,36 @@
                 class="pa-0"
               >
                 <v-list-item class="pa-0">
-                  <v-list-item-avatar
-                    v-if="j === 0"
-                    class="mr-0"
-                  >
-                    <v-icon size="18">
-                      {{ i % 2 ? 'mdi-swap-vertical' : `mdi-numeric-${(i+2)/2}-circle` }}
-                    </v-icon>
-                  </v-list-item-avatar>
-                  <v-row no-gutters>
-                    <v-col
-                      v-if="j > 0"
-                      cols="12"
-                      sm="2"
-                      class="pt-3"
-                    >
-                      <v-autocomplete
-                        v-model="inputs.operator"
-                        :items="operatorOptionItems"
-                        dense
-                      />
-                    </v-col>
-                    <v-list-item-content class="pa-0 pr-1">
+                  <v-list-item-content class="pa-0 pr-1">
+                    <v-row no-gutters>
                       <v-col
-                        cols="12"
-                        sm="3"
+                        cols="1"
                         class="pa-1"
                       >
+                        <v-autocomplete
+                          v-if="j > 0"
+                          v-model="inputs.operator"
+                          :items="operatorOptionItems"
+                          dense
+                        />
+                        <div
+                          v-else
+                          class="text-center pt-3"
+                        >
+                          <v-icon size="18">
+                            {{ i % 2 ? 'mdi-swap-vertical' : `mdi-numeric-${(i+2)/2}-circle` }}
+                          </v-icon>
+                        </div>
+                      </v-col>
+
+                      <v-col class="pa-1">
                         <v-autocomplete
                           v-model="val.label"
                           :items="i % 2 ? edgeVariableItems : nodeVariableItems"
                           dense
                         />
                       </v-col>
-                      <v-col
-                        cols="12"
-                        sm="3"
-                        class="pa-1"
-                      >
+                      <v-col class="pa-1">
                         <v-autocomplete
                           v-model="val.operator"
                           :items="queryOptionItems"
@@ -98,8 +90,6 @@
                         />
                       </v-col>
                       <v-col
-                        cols="12"
-                        sm="3"
                         class="pa-1"
                       >
                         <v-autocomplete
@@ -115,8 +105,7 @@
                         />
                       </v-col>
                       <v-col
-                        cols="12"
-                        sm="1"
+                        cols="1"
                         class="mt-3"
                       >
                         <!-- Add button -->
@@ -132,7 +121,7 @@
                         </v-btn>
                         <!-- Remove button -->
                         <v-btn
-                          v-show="j > 0"
+                          :disabled="j === 0"
                           icon
                           x-small
                           color="red"
@@ -143,36 +132,38 @@
                           </v-icon>
                         </v-btn>
                       </v-col>
-                    </v-list-item-content>
-                  </v-row>
+                    </v-row>
+                  </v-list-item-content>
                 </v-list-item>
               </v-list-item>
             </v-list>
 
             <!-- Let user query for another edge -->
-            <v-card-actions v-if="i === 1">
-              <v-btn
-                text
-              >
-                {{ showSecondEdge ? 'No other path with' : '' }}
-              </v-btn>
+            <v-list-item v-if="i === 1">
+              <v-row>
+                <v-col
+                  class=""
+                >
+                  {{ showSecondEdge ? 'No other path with' : '' }}
+                </v-col>
 
-              <v-spacer />
-              <v-tooltip right>
-                <template v-slot:activator="{ on, attrs }">
-                  <v-btn
-                    icon
-                    color="orange lighten-2"
-                    v-bind="attrs"
-                    @click="showSecondEdge = !showSecondEdge"
-                    v-on="on"
-                  >
-                    <v-icon>{{ showSecondEdge ? 'mdi-minus' : 'mdi-plus' }}</v-icon>
-                  </v-btn>
-                </template>
-                <span>{{ showSecondEdge ? 'Remove edge' : 'Add new edge' }}</span>
-              </v-tooltip>
-            </v-card-actions>
+                <v-spacer />
+                <v-tooltip right>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      icon
+                      color="orange lighten-2"
+                      v-bind="attrs"
+                      @click="showSecondEdge = !showSecondEdge"
+                      v-on="on"
+                    >
+                      <v-icon>{{ showSecondEdge ? 'mdi-minus' : 'mdi-plus' }}</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>{{ showSecondEdge ? 'Remove edge' : 'Add new edge' }}</span>
+                </v-tooltip>
+              </v-row>
+            </v-list-item>
             <v-expand-transition>
               <div v-show="showSecondEdge && i === 1">
                 <v-list dense>
@@ -182,47 +173,42 @@
                     class="pa-0"
                   >
                     <v-list-item class="pa-0">
-                      <v-row no-gutters>
-                        <v-col
-                          v-if="k > 0"
-                          cols="12"
-                          sm="2"
-                          class="pt-3"
-                        >
-                          <v-autocomplete
-                            v-model="edgeMutexs.operator"
-                            :items="operatorOptionItems"
-                            dense
-                          />
-                        </v-col>
-                        <v-list-item-content class="pa-0 pr-1">
+                      <v-list-item-content class="pa-0 pr-1">
+                        <v-row no-gutters>
                           <v-col
-                            cols="12"
-                            sm="3"
+                            cols="1"
                             class="pa-1"
                           >
+                            <v-autocomplete
+                              v-if="k > 0"
+                              v-model="edgeMutexs.operator"
+                              :items="operatorOptionItems"
+                              dense
+                            />
+                            <div
+                              v-else
+                              class="text-center pt-3"
+                            >
+                              <v-icon size="18">
+                                mdi-swap-vertical
+                              </v-icon>
+                            </div>
+                          </v-col>
+                          <v-col class="pa-1">
                             <v-autocomplete
                               v-model="val.label"
                               :items="edgeVariableItems"
                               dense
                             />
                           </v-col>
-                          <v-col
-                            cols="12"
-                            sm="3"
-                            class="pa-1"
-                          >
+                          <v-col class="pa-1">
                             <v-autocomplete
                               v-model="val.operator"
                               :items="queryOptionItems"
                               dense
                             />
                           </v-col>
-                          <v-col
-                            cols="12"
-                            sm="3"
-                            class="pa-1"
-                          >
+                          <v-col class="pa-1">
                             <v-autocomplete
                               v-if="val.operator === '=='"
                               v-model="val.input"
@@ -253,7 +239,7 @@
                             </v-btn>
                             <!-- Remove button -->
                             <v-btn
-                              v-show="k > 0"
+                              :disabled="k === 0"
                               icon
                               x-small
                               color="red"
@@ -264,8 +250,8 @@
                               </v-icon>
                             </v-btn>
                           </v-col>
-                        </v-list-item-content>
-                      </v-row>
+                        </v-row>
+                      </v-list-item-content>
                     </v-list-item>
                   </v-list-item>
                 </v-list>
@@ -375,12 +361,20 @@ export default defineComponent({
 
     onMounted(() => resetDefaultValues());
 
-    function addField(index: number) {
-      queryInput.value[index].value.push({ input: '', label: '', operator: '=~' });
+    function addField(index: number, edgeMutex = false) {
+      if (edgeMutex) {
+        edgeMutexs.value.value.push({ input: '', label: '', operator: '=~' });
+      } else {
+        queryInput.value[index].value.push({ input: '', label: '', operator: '=~' });
+      }
     }
 
-    function removeField(index: number, field: number) {
-      queryInput.value[index].value.splice(field, 1);
+    function removeField(index: number, field: number, edgeMutex = false) {
+      if (edgeMutex) {
+        edgeMutexs.value.value.splice(field, 1);
+      } else {
+        queryInput.value[index].value.splice(field, 1);
+      }
     }
 
     function isTextComparison(operator: string) {
@@ -471,7 +465,6 @@ export default defineComponent({
 
       // Join each line of the query together
       const aqlQuery = pathQueryTextComponents.join('\n');
-
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let newAQLNetwork: Promise<any[]> | undefined;
       try {

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -439,12 +439,15 @@ export default defineComponent({
 
             // Add mutual exclusion filters
             const { operator } = edgeMutexs.value;
-            edgeMutexs.value.value.forEach((queryPiece) => {
+            edgeMutexs.value.value.forEach((queryPiece, index) => {
+              if (index !== 0) {
+                currentString += `${operator} `;
+              }
               const property = isTextComparison(queryPiece.operator) ? `UPPER(e1.${queryPiece.label})` : `TO_NUMBER(e1.${queryPiece.label})`;
 
               const value = isTextComparison(queryPiece.operator) ? `UPPER('${queryPiece.input}')` : `TO_NUMBER(${queryPiece.input})`;
 
-              currentString += `${property} ${queryPiece.operator} ${value} ${operator} `;
+              currentString += `${property} ${queryPiece.operator} ${value} `;
             });
 
             // Add filter ending parenthesis

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -5,187 +5,71 @@
 
       <v-spacer />
 
-      <v-btn
-        :min-width="40"
-        :height="48"
-        depressed
-        tile
-        class="grey darken-3 pa-0"
-        @click="showMenu = !showMenu"
+      <v-dialog
+        v-model="dialog"
+        max-width="600px"
       >
-        <v-icon color="white">
-          {{ showMenu ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
-        </v-icon>
-      </v-btn>
-    </v-subheader>
-
-    <div v-if="showMenu">
-      <v-card
-        flat
-        tile
-      >
-        <v-card-text class="pt-2 pb-1">
-          <v-select
-            v-model="selectedHops"
-            label="Hops"
-            :items="hopsSelection"
-          />
-        </v-card-text>
-      </v-card>
-
-      <v-card
-        v-for="(inputs, i) in queryInput"
-        :key="`input${i}`"
-        flat
-        color="white"
-        class="p-0"
-      >
-        <!-- All of the query options -->
-        <v-list dense>
-          <v-list-item
-            v-for="(val, j) in inputs.value"
-            :key="`val-${i}-${j}`"
-            class="pa-0"
-          >
-            <v-list-item class="pa-0">
-              <v-list-item-avatar
-                v-if="j === 0"
-                class="mr-0"
-              >
-                <v-icon size="18">
-                  {{ i % 2 ? 'mdi-swap-vertical' : `mdi-numeric-${(i+2)/2}-circle` }}
-                </v-icon>
-              </v-list-item-avatar>
-              <v-row no-gutters>
-                <v-col
-                  v-if="j > 0"
-                  cols="12"
-                  sm="2"
-                  class="pt-3"
-                >
-                  <v-autocomplete
-                    v-model="inputs.operator"
-                    :items="operatorOptionItems"
-                    dense
-                  />
-                </v-col>
-                <v-list-item-content class="pa-0 pr-1">
-                  <v-col
-                    cols="12"
-                    sm="3"
-                    class="pa-1"
-                  >
-                    <v-autocomplete
-                      v-model="val.label"
-                      :items="i % 2 ? edgeVariableItems : nodeVariableItems"
-                      dense
-                    />
-                  </v-col>
-                  <v-col
-                    cols="12"
-                    sm="3"
-                    class="pa-1"
-                  >
-                    <v-autocomplete
-                      v-model="val.operator"
-                      :items="queryOptionItems"
-                      dense
-                    />
-                  </v-col>
-                  <v-col
-                    cols="12"
-                    sm="3"
-                    class="pa-1"
-                  >
-                    <v-autocomplete
-                      v-if="val.operator === '=='"
-                      v-model="val.input"
-                      :items="i % 2 ? edgeAttributeItems[val.label] : nodeAttributeItems[val.label]"
-                      dense
-                    />
-                    <v-text-field
-                      v-else
-                      v-model="val.input"
-                      dense
-                    />
-                  </v-col>
-                  <v-col
-                    cols="12"
-                    sm="1"
-                    class="mt-3"
-                  >
-                    <!-- Add button -->
-                    <v-btn
-                      icon
-                      x-small
-                      color="primary"
-                      @click="addField(i)"
-                    >
-                      <v-icon>
-                        mdi-plus
-                      </v-icon>
-                    </v-btn>
-                    <!-- Remove button -->
-                    <v-btn
-                      v-show="j > 0"
-                      icon
-                      x-small
-                      color="red"
-                      @click="removeField(i, j)"
-                    >
-                      <v-icon>
-                        mdi-minus
-                      </v-icon>
-                    </v-btn>
-                  </v-col>
-                </v-list-item-content>
-              </v-row>
-            </v-list-item>
-          </v-list-item>
-        </v-list>
-
-        <!-- Let user query for another edge -->
-        <v-card-actions v-if="i === 1">
+        <template v-slot:activator="{ on, attrs }">
           <v-btn
-            text
+            :min-width="40"
+            :height="48"
+            depressed
+            tile
+            dark
+            color="grey darken-3"
+            class="pa-0"
+            :loading="loading"
+            v-bind="attrs"
+            v-on="on"
           >
-            {{ showSecondEdge ? 'No other path with' : '' }}
+            <v-icon>
+              mdi-arrow-right
+            </v-icon>
           </v-btn>
+        </template>
 
-          <v-spacer />
-          <v-tooltip right>
-            <template v-slot:activator="{ on, attrs }">
-              <v-btn
-                icon
-                color="orange lighten-2"
-                v-bind="attrs"
-                @click="showSecondEdge = !showSecondEdge"
-                v-on="on"
-              >
-                <v-icon>{{ showSecondEdge ? 'mdi-minus' : 'mdi-plus' }}</v-icon>
-              </v-btn>
-            </template>
-            <span>{{ showSecondEdge ? 'Remove edge' : 'Add new edge' }}</span>
-          </v-tooltip>
-        </v-card-actions>
-        <v-expand-transition>
-          <div v-show="showSecondEdge && i === 1">
+        <v-card>
+          <v-card-text class="pt-2 pb-1">
+            <v-select
+              v-model="selectedHops"
+              label="Hops"
+              :items="hopsSelection"
+            />
+          </v-card-text>
+
+          <v-card
+            v-for="(inputs, i) in queryInput"
+            :key="`input${i}`"
+            flat
+            color="white"
+            class="p-0"
+          >
+            <v-divider v-if="i % 2" />
+            <!-- All of the query options -->
             <v-list dense>
               <v-list-item
-                v-for="(val, k) in edgeMutexs.value"
-                :key="`val-${i}-2-${k}`"
+                v-for="(val, j) in inputs.value"
+                :key="`val-${i}-${j}`"
                 class="pa-0"
               >
                 <v-list-item class="pa-0">
+                  <v-list-item-avatar
+                    v-if="j === 0"
+                    class="mr-0"
+                  >
+                    <v-icon size="18">
+                      {{ i % 2 ? 'mdi-swap-vertical' : `mdi-numeric-${(i+2)/2}-circle` }}
+                    </v-icon>
+                  </v-list-item-avatar>
                   <v-row no-gutters>
                     <v-col
-                      v-if="k > 0"
+                      v-if="j > 0"
                       cols="12"
                       sm="2"
                       class="pt-3"
                     >
                       <v-autocomplete
-                        v-model="edgeMutexs.operator"
+                        v-model="inputs.operator"
                         :items="operatorOptionItems"
                         dense
                       />
@@ -198,7 +82,7 @@
                       >
                         <v-autocomplete
                           v-model="val.label"
-                          :items="edgeVariableItems"
+                          :items="i % 2 ? edgeVariableItems : nodeVariableItems"
                           dense
                         />
                       </v-col>
@@ -221,7 +105,7 @@
                         <v-autocomplete
                           v-if="val.operator === '=='"
                           v-model="val.input"
-                          :items="edgeAttributeItems[val.label]"
+                          :items="i % 2 ? edgeAttributeItems[val.label] : nodeAttributeItems[val.label]"
                           dense
                         />
                         <v-text-field
@@ -240,7 +124,7 @@
                           icon
                           x-small
                           color="primary"
-                          @click="addField(i, true)"
+                          @click="addField(i)"
                         >
                           <v-icon>
                             mdi-plus
@@ -248,11 +132,11 @@
                         </v-btn>
                         <!-- Remove button -->
                         <v-btn
-                          v-show="k > 0"
+                          v-show="j > 0"
                           icon
                           x-small
                           color="red"
-                          @click="removeField(i, k, true)"
+                          @click="removeField(i, j)"
                         >
                           <v-icon>
                             mdi-minus
@@ -264,23 +148,147 @@
                 </v-list-item>
               </v-list-item>
             </v-list>
-          </div>
-        </v-expand-transition>
-      </v-card>
 
-      <v-list-item>
-        <v-btn
-          block
-          class="ml-0 mt-4"
-          color="primary"
-          depressed
-          :loading="loading"
-          @click="submitQuery"
-        >
-          Submit Query
-        </v-btn>
-      </v-list-item>
-    </div>
+            <!-- Let user query for another edge -->
+            <v-card-actions v-if="i === 1">
+              <v-btn
+                text
+              >
+                {{ showSecondEdge ? 'No other path with' : '' }}
+              </v-btn>
+
+              <v-spacer />
+              <v-tooltip right>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-btn
+                    icon
+                    color="orange lighten-2"
+                    v-bind="attrs"
+                    @click="showSecondEdge = !showSecondEdge"
+                    v-on="on"
+                  >
+                    <v-icon>{{ showSecondEdge ? 'mdi-minus' : 'mdi-plus' }}</v-icon>
+                  </v-btn>
+                </template>
+                <span>{{ showSecondEdge ? 'Remove edge' : 'Add new edge' }}</span>
+              </v-tooltip>
+            </v-card-actions>
+            <v-expand-transition>
+              <div v-show="showSecondEdge && i === 1">
+                <v-list dense>
+                  <v-list-item
+                    v-for="(val, k) in edgeMutexs.value"
+                    :key="`val-${i}-2-${k}`"
+                    class="pa-0"
+                  >
+                    <v-list-item class="pa-0">
+                      <v-row no-gutters>
+                        <v-col
+                          v-if="k > 0"
+                          cols="12"
+                          sm="2"
+                          class="pt-3"
+                        >
+                          <v-autocomplete
+                            v-model="edgeMutexs.operator"
+                            :items="operatorOptionItems"
+                            dense
+                          />
+                        </v-col>
+                        <v-list-item-content class="pa-0 pr-1">
+                          <v-col
+                            cols="12"
+                            sm="3"
+                            class="pa-1"
+                          >
+                            <v-autocomplete
+                              v-model="val.label"
+                              :items="edgeVariableItems"
+                              dense
+                            />
+                          </v-col>
+                          <v-col
+                            cols="12"
+                            sm="3"
+                            class="pa-1"
+                          >
+                            <v-autocomplete
+                              v-model="val.operator"
+                              :items="queryOptionItems"
+                              dense
+                            />
+                          </v-col>
+                          <v-col
+                            cols="12"
+                            sm="3"
+                            class="pa-1"
+                          >
+                            <v-autocomplete
+                              v-if="val.operator === '=='"
+                              v-model="val.input"
+                              :items="edgeAttributeItems[val.label]"
+                              dense
+                            />
+                            <v-text-field
+                              v-else
+                              v-model="val.input"
+                              dense
+                            />
+                          </v-col>
+                          <v-col
+                            cols="12"
+                            sm="1"
+                            class="mt-3"
+                          >
+                            <!-- Add button -->
+                            <v-btn
+                              icon
+                              x-small
+                              color="primary"
+                              @click="addField(i, true)"
+                            >
+                              <v-icon>
+                                mdi-plus
+                              </v-icon>
+                            </v-btn>
+                            <!-- Remove button -->
+                            <v-btn
+                              v-show="k > 0"
+                              icon
+                              x-small
+                              color="red"
+                              @click="removeField(i, k, true)"
+                            >
+                              <v-icon>
+                                mdi-minus
+                              </v-icon>
+                            </v-btn>
+                          </v-col>
+                        </v-list-item-content>
+                      </v-row>
+                    </v-list-item>
+                  </v-list-item>
+                </v-list>
+              </div>
+            </v-expand-transition>
+            <v-divider v-if="i % 2" />
+          </v-card>
+
+          <v-list-item>
+            <v-btn
+              block
+              class="mb-2"
+              color="primary"
+              depressed
+              :loading="loading"
+              @click="() => { submitQuery(); dialog = false}"
+            >
+              Submit Query
+            </v-btn>
+          </v-list-item>
+        </v-card>
+      </v-dialog>
+    </v-subheader>
   </div>
 </template>
 
@@ -425,7 +433,7 @@ export default defineComponent({
         currentString += ') ';
 
         // Add to the filter for edge mutex
-        if (input.key === 1) {
+        if (input.key === 1 && showSecondEdge.value) {
           currentString += 'AND (NOT POSITION(excluded_pairs, [n0, n1]))';
         }
 

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -197,6 +197,15 @@ export default defineComponent({
     const queryOptionItems = ['==', '=~', '!=', '<', '<=', '>', '>='];
     const operatorOptionItems = ['AND', 'OR', 'NOT'];
 
+    const directionalEdges = computed({
+      get() {
+        return store.state.directionalEdges;
+      },
+      set(value: boolean) {
+        store.commit.setDirectionalEdges(value);
+      },
+    });
+
     // Create the object for storing input data
     const queryInput: Ref<{ key: number; value: { label: string; operator: string; input: string }[]; operator: string }[]> = ref([]);
 
@@ -240,6 +249,7 @@ export default defineComponent({
 
     function submitQuery() {
       loading.value = true;
+      directionalEdges.value = true;
       const pathQueryTextComponents: string[] = [];
 
       // Loop through nodes and edges

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -99,7 +99,7 @@
                     <v-autocomplete
                       v-if="val.operator === '=='"
                       v-model="val.input"
-                      :items="i % 2 ? variableValueItems.edge[val.label] : variableValueItems.node[val.label]"
+                      :items="i % 2 ? edgeAttributeItems[val.label] : nodeAttributeItems[val.label]"
                       dense
                     />
                     <v-text-field
@@ -190,23 +190,12 @@ export default defineComponent({
     const selectedVariables: Ref<string[]> = ref([]);
     const nodeVariableItems = computed(() => store.getters.nodeVariableItems);
     const edgeVariableItems = computed(() => store.getters.edgeVariableItems);
+    const nodeAttributeItems = computed(() => store.state.nodeAttributes);
+    const edgeAttributeItems = computed(() => store.state.edgeAttributes);
 
     const selectedQueryOptions: Ref<string[]> = ref([]);
     const queryOptionItems = ['==', '=~', '!=', '<', '<=', '>', '>='];
     const operatorOptionItems = ['AND', 'OR', 'NOT'];
-
-    const variableValueItems = computed(() => {
-      const variableItems: { node: { [key: string]: string[] }; edge: { [key: string]: string[] } } = { node: {}, edge: {} };
-      if (store.state.network !== null) {
-        nodeVariableItems.value.forEach((nodeVariable) => {
-          variableItems.node[nodeVariable] = store.state.nodeAttributes[nodeVariable].map((value) => `${value}`);
-        });
-        edgeVariableItems.value.forEach((edgeVariable: string) => {
-          variableItems.edge[edgeVariable] = store.state.edgeAttributes[edgeVariable].map((value) => `${value}`);
-        });
-      }
-      return variableItems;
-    });
 
     // Create the object for storing input data
     const queryInput: Ref<{ key: number; value: { label: string; operator: string; input: string }[]; operator: string }[]> = ref([]);
@@ -219,7 +208,7 @@ export default defineComponent({
           };
         }
         return {
-          key: i, value: [{ label: '', operator: '=~', input: '' }], operator: '',
+          key: i, value: [{ label: 'Label', operator: '=~', input: '' }], operator: '',
         };
       });
     });
@@ -232,7 +221,7 @@ export default defineComponent({
           };
         }
         return {
-          key: i, value: [{ label: '', operator: '=~', input: '' }], operator: '',
+          key: i, value: [{ label: 'Label', operator: '=~', input: '' }], operator: '',
         };
       });
     });
@@ -402,7 +391,8 @@ export default defineComponent({
       selectedQueryOptions,
       nodeVariableItems,
       edgeVariableItems,
-      variableValueItems,
+      nodeAttributeItems,
+      edgeAttributeItems,
       submitQuery,
       loading,
       addField,

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -20,7 +20,7 @@ export default defineComponent({
 
   setup() {
     // Template objects
-    const showTabs = ref(false);
+    const showQuery = ref(false);
     const tab = ref(false);
     const showMenu = ref(false);
     const aggregateBy = ref(undefined);
@@ -196,7 +196,7 @@ export default defineComponent({
     }
 
     return {
-      showTabs,
+      showQuery,
       tab,
       aggregateBy,
       directionalEdges,
@@ -503,48 +503,19 @@ export default defineComponent({
               :height="48"
               depressed
               tile
-              :class="showTabs? `grey darken-2 pa-0` : `grey darken-3 pa-0`"
-              @click="showTabs = !showTabs"
+              :class="showQuery? `grey darken-2 pa-0` : `grey darken-3 pa-0`"
+              @click="showQuery = !showQuery"
             >
               <v-icon color="white">
                 mdi-cog
               </v-icon>
             </v-btn>
           </v-subheader>
-
-          <v-tabs
-            v-if="showTabs"
-            v-model="tab"
-            background-color="grey darken-2"
-            dark
-            grow
-            slider-color="blue darken-1"
+          <v-div
+            v-if="showQuery"
           >
-            <v-tab>
-              Basic
-            </v-tab>
-            <v-tab>
-              Advanced
-            </v-tab>
-          </v-tabs>
-
-          <v-tabs-items
-            v-if="showTabs"
-            v-model="tab"
-            dark
-          >
-            <v-tab-item>
-              <v-card
-                flat
-                color="grey darken-3"
-                class="pb-4 pt-2"
-              >
-                <connectivity-query />
-              </v-card>
-            </v-tab-item>
-
-            <v-tab-item />
-          </v-tabs-items>
+            <connectivity-query />
+          </v-div>
         </div>
       </v-list>
     </v-navigation-drawer>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -22,8 +22,6 @@ export default defineComponent({
 
   setup() {
     // Template objects
-    const showQuery = ref(false);
-    const tab = ref(false);
     const showMenu = ref(false);
     const aggregateBy = ref(undefined);
     const directionalEdges = computed({
@@ -206,8 +204,6 @@ export default defineComponent({
     }
 
     return {
-      showQuery,
-      tab,
       aggregateBy,
       directionalEdges,
       selectNeighbors,

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -20,7 +20,8 @@ export default defineComponent({
 
   setup() {
     // Template objects
-    const connectivityQueryToggle = ref(false);
+    const showTabs = ref(false);
+    const tab = ref(false);
     const aggregateBy = ref('none');
     const directionalEdges = computed({
       get() {
@@ -152,7 +153,8 @@ export default defineComponent({
     }
 
     return {
-      connectivityQueryToggle,
+      showTabs,
+      tab,
       aggregateBy,
       directionalEdges,
       selectNeighbors,
@@ -253,18 +255,6 @@ export default defineComponent({
               />
             </v-list-item-action>
             <v-list-item-content> Directional Edges </v-list-item-content>
-          </v-list-item>
-
-          <!-- Connectivity Query List Item -->
-          <v-list-item class="px-0">
-            <v-list-item-action class="mr-3">
-              <v-switch
-                v-model="connectivityQueryToggle"
-                class="ma-0"
-                hide-details
-              />
-            </v-list-item-action>
-            <v-list-item-content> Enable Connectivity Query </v-list-item-content>
           </v-list-item>
 
           <!-- Connectivity Query List Item -->
@@ -397,12 +387,60 @@ export default defineComponent({
         </div>
 
         <!-- Connectivity Query -->
-        <div v-if="connectivityQueryToggle">
-          <v-subheader class="grey darken-3 mt-6 py-0 white--text">
+        <v-list class="pa-0">
+          <v-subheader class="grey darken-3 py-0 pr-0 white--text">
             Connectivity Query
+
+            <v-spacer />
+
+            <v-btn
+              :min-width="40"
+              :height="48"
+              depressed
+              tile
+              :class="showTabs? `grey darken-2 pa-0` : `grey darken-3 pa-0`"
+              @click="showTabs = !showTabs"
+            >
+              <v-icon color="white">
+                mdi-cog
+              </v-icon>
+            </v-btn>
           </v-subheader>
-          <connectivity-query />
-        </div>
+
+          <v-tabs
+            v-if="showTabs"
+            v-model="tab"
+            background-color="grey darken-2"
+            dark
+            grow
+            slider-color="blue darken-1"
+          >
+            <v-tab>
+              Basic
+            </v-tab>
+            <v-tab>
+              Advanced
+            </v-tab>
+          </v-tabs>
+
+          <v-tabs-items
+            v-if="showTabs"
+            v-model="tab"
+            dark
+          >
+            <v-tab-item>
+              <v-card
+                flat
+                color="grey darken-3"
+                class="pb-4 pt-2"
+              >
+                <connectivity-query />
+              </v-card>
+            </v-tab-item>
+
+            <v-tab-item />
+          </v-tabs-items>
+        </v-list>
       </v-list>
     </v-navigation-drawer>
   </div>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #335 
Closes #282 

### Give a longer description of what this PR addresses and why it's needed
This PR will make it so that a user can conduct advanced querying of the connectivity network.
At the moment we can only query for one attribute per node or edge, and we'd like to query for more than one attribute.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] Create UI for expanding + collapsing querying
- [x] Update AQL queries to work with multi-attribute querying