### PR TITLE
Start connectivity query collapsed, allow expansion with chevron

### DIFF
--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -1,87 +1,112 @@
 <template>
   <div class="pa-0">
+    <v-subheader class="grey darken-3 py-0 pr-0 white--text">
+      Connectivity Query
+
+      <v-spacer />
+
+      <v-btn
+        :min-width="40"
+        :height="48"
+        depressed
+        tile
+        class="grey darken-3 pa-0"
+        @click="showMenu = !showMenu"
+      >
+        <v-icon color="white">
+          {{ showMenu ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
+        </v-icon>
+      </v-btn>
+    </v-subheader>
+
     <v-card
-      color="grey lighten-3"
+      v-if="showMenu"
       flat
       tile
     >
-      <v-card-text class="pt-2 pb-1">
-        <v-select
-          v-model="selectedHops"
-          label="Hops"
-          :items="hopsSelection"
-        />
-      </v-card-text>
-    </v-card>
-    <v-list dense>
-      <v-list-item
-        v-for="(_, i) in displayedHops"
-        :key="i"
-        class="pa-0"
+      <v-card
+        color="grey lighten-3"
+        flat
+        tile
       >
-        <v-list-item-avatar class="mr-0">
-          <v-icon size="18">
-            {{ i % 2 ? 'mdi-swap-vertical' : `mdi-numeric-${(i+2)/2}-circle` }}
-          </v-icon>
-        </v-list-item-avatar>
-        <v-list-item-content class="pa-0 pr-1">
-          <v-row no-gutters>
-            <v-col
-              cols="12"
-              sm="5"
-              class="pa-1"
-            >
-              <v-autocomplete
-                v-model="selectedVariables[i]"
-                :items="i % 2 ? edgeVariableItems : nodeVariableItems"
-                dense
-              />
-            </v-col>
-            <v-col
-              cols="12"
-              sm="3"
-              class="pa-1"
-            >
-              <v-autocomplete
-                v-model="selectedQueryOptions[i]"
-                :items="queryOptionItems"
-                dense
-              />
-            </v-col>
-            <v-col
-              cols="12"
-              sm="4"
-              class="pa-1"
-            >
-              <v-autocomplete
-                v-if="selectedQueryOptions[i] === '=='"
-                v-model="selectedVariableValue[i]"
-                :items="variableValueItems[i]"
-                dense
-              />
-              <v-text-field
-                v-else
-                v-model="selectedVariableValue[i]"
-                dense
-              />
-            </v-col>
-          </v-row>
-        </v-list-item-content>
-      </v-list-item>
-
-      <v-list-item>
-        <v-btn
-          block
-          class="ml-0 mt-4"
-          color="primary"
-          depressed
-          :loading="loading"
-          @click="submitQuery"
+        <v-card-text class="pt-2 pb-1">
+          <v-select
+            v-model="selectedHops"
+            label="Hops"
+            :items="hopsSelection"
+          />
+        </v-card-text>
+      </v-card>
+      <v-list dense>
+        <v-list-item
+          v-for="(_, i) in displayedHops"
+          :key="i"
+          class="pa-0"
         >
-          Submit Query
-        </v-btn>
-      </v-list-item>
-    </v-list>
+          <v-list-item-avatar class="mr-0">
+            <v-icon size="18">
+              {{ i % 2 ? 'mdi-swap-vertical' : `mdi-numeric-${(i+2)/2}-circle` }}
+            </v-icon>
+          </v-list-item-avatar>
+          <v-list-item-content class="pa-0 pr-1">
+            <v-row no-gutters>
+              <v-col
+                cols="12"
+                sm="5"
+                class="pa-1"
+              >
+                <v-autocomplete
+                  v-model="selectedVariables[i]"
+                  :items="i % 2 ? edgeVariableItems : nodeVariableItems"
+                  dense
+                />
+              </v-col>
+              <v-col
+                cols="12"
+                sm="3"
+                class="pa-1"
+              >
+                <v-autocomplete
+                  v-model="selectedQueryOptions[i]"
+                  :items="queryOptionItems"
+                  dense
+                />
+              </v-col>
+              <v-col
+                cols="12"
+                sm="4"
+                class="pa-1"
+              >
+                <v-autocomplete
+                  v-if="selectedQueryOptions[i] === '=='"
+                  v-model="selectedVariableValue[i]"
+                  :items="variableValueItems[i]"
+                  dense
+                />
+                <v-text-field
+                  v-else
+                  v-model="selectedVariableValue[i]"
+                  dense
+                />
+              </v-col>
+            </v-row>
+          </v-list-item-content>
+        </v-list-item>
+
+        <v-list-item>
+          <v-btn
+            block
+            class="ml-0 mt-4"
+            color="primary"
+            depressed
+            :loading="loading"
+            @click="submitQuery"
+          >
+            Submit Query
+          </v-btn>
+        </v-list-item>
+      </v-list>
+    </v-card>
   </div>
 </template>
 
@@ -97,6 +122,7 @@ export default defineComponent({
   name: 'ConnectivityQuery',
 
   setup() {
+    const showMenu = ref(false);
     const hopsSelection = [1, 2, 3, 4, 5];
     const selectedHops: Ref<number> = ref(1);
     const displayedHops = computed(() => 2 * selectedHops.value + 1);
@@ -123,7 +149,7 @@ export default defineComponent({
       selectedVariables.value.forEach((variable: string, i: number) => {
         if (store.state.network !== null) {
           const currentData = i % 2 ? store.state.edgeAttributes : store.state.nodeAttributes;
-          if (variable) {
+          if (variable && Object.keys(currentData).length > 0) {
             variableValueItems.value[i] = currentData[variable].map((value) => `${value}`);
           }
         }
@@ -233,6 +259,7 @@ export default defineComponent({
       }
     }
     return {
+      showMenu,
       hopsSelection,
       selectedHops,
       displayedHops,

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -498,12 +498,7 @@ export default defineComponent({
         </div>
 
         <!-- Connectivity Query -->
-        <div>
-          <v-subheader class="grey darken-3 py-0 white--text">
-            Connectivity Query
-          </v-subheader>
-          <connectivity-query />
-        </div>
+        <connectivity-query />
       </v-list>
     </v-navigation-drawer>
   </div>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #375

### Give a longer description of what this PR addresses and why it's needed
I made this fix in an attempt to fix something else that didn't need this. Since I had the code already, I figured I should submit it for PR. 

The changes are simple. This PR just makes the connectivity query start collapsed and be expandable with the chevron as our other menu items are

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
![image](https://user-images.githubusercontent.com/36867477/153959040-02edcb58-83dc-40ee-b8dc-1b7f99df6fac.png)

Now:
![image](https://user-images.githubusercontent.com/36867477/153959005-906c6afe-9388-4fbb-ba0e-e693bb93c760.png)


### Are there any additional TODOs before this PR is ready to go?
No