### PR TITLE
Fix sorting

### DIFF
--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -35,6 +35,30 @@ export default defineComponent({
       return 330;
     });
 
+    const sortOrder = computed(() => store.state.sortOrder);
+    const lineupOrder = computed(() => {
+      if (lineup.value === null || [...lineup.value.data.getFirstRanking().getOrder()].length === 0) {
+        return [...Array(network.value?.nodes.length).keys()];
+      }
+      return [...lineup.value.data.getFirstRanking().getOrder()];
+    });
+
+    // If store order has changed, update lineup
+    watch(sortOrder, (newSortOrder) => {
+      if (lineup.value !== null) {
+        const sortedData = newSortOrder.map((i) => (network.value !== null ? network.value.nodes[i] : {}));
+        (lineup.value.data as LocalDataProvider).setData(sortedData);
+      }
+    });
+
+    // If lineup order has changed, update matrix
+    watch(lineupOrder, (newLineupOrder) => {
+      if (lineup.value !== null && network.value !== null && JSON.stringify(newLineupOrder) !== JSON.stringify([...Array(network.value.nodes.length).keys()])) {
+        const newSortOrder = newLineupOrder.map((i) => sortOrder.value[i]);
+        store.commit.setSortOrder(newSortOrder);
+      }
+    });
+
     // Helper functions
     function idsToIndices(ids: string[]) {
       return ids
@@ -138,31 +162,6 @@ export default defineComponent({
         lineup.value.setSelection(indices);
       }
     });
-
-    const sortOrder = computed(() => store.state.sortOrder);
-    const lineupOrder = computed(() => {
-      if (lineup.value === null || [...lineup.value.data.getFirstRanking().getOrder()].length === 0) {
-        return [...Array(network.value?.nodes.length).keys()];
-      }
-      return [...lineup.value.data.getFirstRanking().getOrder()];
-    });
-
-    // If store order has changed, update lineup
-    watch(sortOrder, (newSortOrder) => {
-      if (lineup.value !== null) {
-        const sortedData = newSortOrder.map((i) => (network.value !== null ? network.value.nodes[i] : {}));
-        (lineup.value.data as LocalDataProvider).setData(sortedData);
-      }
-    });
-
-    // If lineup order has changed, update matrix
-    watch(lineupOrder, (newLineupOrder) => {
-      if (lineup.value !== null && network.value !== null && JSON.stringify(newLineupOrder) !== JSON.stringify([...Array(network.value.nodes.length).keys()])) {
-        const newSortOrder = newLineupOrder.map((i) => sortOrder.value[i]);
-        store.commit.setSortOrder(newSortOrder);
-      }
-    });
-
     watch(network, () => {
       removeLineup();
       buildLineup();

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -6,6 +6,7 @@ import {
 import LineUp, { DataBuilder, LocalDataProvider } from 'lineupjs';
 import { select } from 'd3-selection';
 import { isInternalField } from '@/lib/typeUtils';
+import { Node } from '@/types';
 
 export default defineComponent({
   name: 'LineUp',
@@ -119,9 +120,9 @@ export default defineComponent({
           .build(lineupDiv);
 
         // Add an event watcher to update selected nodes
-        lineup.value.on('selectionChanged', (dataindices: number[]) => {
+        lineup.value.on('selectionChanged', (dataIndices: number[]) => {
           // Transform data indices to multinet `_id`s
-          const clickedIDs: string[] = indicesToIDs(dataindices);
+          const clickedIDs: string[] = indicesToIDs(dataIndices);
 
           // Find the symmetric difference between the ids here and those in the store
           function diffFunction<T>(arr1: Array<T>, arr2: Array<T>): Array<T> { return arr1.filter((x) => arr2.indexOf(x) === -1); }
@@ -138,13 +139,13 @@ export default defineComponent({
         let lastHovered = '';
 
         // Add an event watcher to update highlighted nodes
-        lineup.value.on('highlightChanged', (dataindex: number) => {
-          if (dataindex === -1) {
+        lineup.value.on('highlightChanged', (dataIndex: number) => {
+          if (dataIndex === -1) {
             return;
           }
 
           // Transform data indices to multinet `_id`s
-          const hoveredIDs: string[] = indicesToIDs([dataindex]);
+          const hoveredIDs: string[] = indicesToIDs([dataIndex]);
 
           // Hover the elements that are different to add/remove them from the store
           hoveredIDs.forEach((nodeID) => store.commit.pushHoveredNode(nodeID));

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -77,7 +77,11 @@ export default defineComponent({
     });
 
     function indicesToIDs(indices: number[]) {
-      return indices.map((index) => network.value?.nodes[sortOrder.value[index]]._id);
+      if (network.value !== null) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return indices.map((index) => network.value!.nodes[sortOrder.value[index]]._id);
+      }
+      return [];
     }
 
     function removeLineup() {

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -100,7 +100,7 @@ export default defineComponent({
       const lineupDiv = document.getElementById('lineup');
 
       if (network.value !== null && lineupDiv !== null) {
-        const columns = [...new Set(network.value.nodes.map((node) => Object.keys(node)).flat())].filter((column) => !isInternalField(column) || column === '_key');
+        const columns = [...new Set(network.value.nodes.map((node) => Object.keys(node)).flat())].filter((column) => !isInternalField(column));
 
         builder.value = new DataBuilder(network.value.nodes);
 

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -273,7 +273,14 @@ export default defineComponent({
       } else if (sortKey.value === 'shortName') {
         order = range(network.value.nodes.length).sort((a, b) => {
           if (network.value === null) { return 0; }
-          return network.value.nodes[a]._id.localeCompare(network.value.nodes[b]._id);
+          const aVal = `${network.value.nodes[a][labelVariable.value === undefined ? '_key' : labelVariable.value]}`;
+          const bVal = `${network.value.nodes[b][labelVariable.value === undefined ? '_key' : labelVariable.value]}`;
+
+          if (!Number.isNaN(parseInt(aVal, 10)) && !Number.isNaN(parseInt(aVal, 10))) {
+            return a < b ? -1 : 1;
+          }
+
+          return aVal.localeCompare(bVal);
         });
       } else {
         order = range(network.value.nodes.length).sort((a, b) => {

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -193,7 +193,12 @@ export default defineComponent({
       event.preventDefault();
     }
 
-    function changeOrder(type: string, isNode = false) {
+    function sort(type: string): void {
+      if (network.value === null) {
+        return;
+      }
+      const isNode = network.value.nodes.map((node: Node) => node._id).includes(type);
+
       if (network.value === null) { return; }
 
       let order;
@@ -254,16 +259,17 @@ export default defineComponent({
 
           return firstValue - secondValue;
         });
-      } else if (isNode === true) {
-        order = range(network.value.nodes.length).sort((a, b) => {
-          if (network.value === null) { return 0; }
-          return network.value.nodes[a]._id.localeCompare(network.value.nodes[b]._id);
-        });
-        order = range(network.value.nodes.length).sort((a, b) => {
-          if (network.value === null) { return 0; }
-          return Number(network.value.nodes[b].neighbors.includes(type))
-            - Number(network.value.nodes[a].neighbors.includes(type));
-        });
+      } else if (isNode) {
+        if (sortKey.value === '') {
+          // Clear sort
+          order = range(network.value.nodes.length);
+        } else {
+          order = range(network.value.nodes.length).sort((a, b) => {
+            if (network.value === null) { return 0; }
+            return Number(network.value.nodes[b].neighbors.includes(type))
+              - Number(network.value.nodes[a].neighbors.includes(type));
+          });
+        }
       } else if (sortKey.value === 'shortName') {
         order = range(network.value.nodes.length).sort((a, b) => {
           if (network.value === null) { return 0; }
@@ -279,15 +285,6 @@ export default defineComponent({
         });
       }
       sortOrder.value = order;
-    }
-
-    function sort(order: string): void {
-      if (network.value === null) {
-        return;
-      }
-      const nodeIDs = network.value.nodes.map((node: Node) => node._id);
-
-      changeOrder(order, nodeIDs.includes(order));
     }
 
     watch(hoveredNodes, () => {

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -64,7 +64,6 @@ export default defineComponent({
           'M115.3,0H6.6C3,0,0,3,0,6.6V123c0,3.7,3,6.6,6.6,6.6h108.7c3.7,0,6.6-3,6.6-6.6V6.6C122,3,119,0,115.3,0zM37.8,128.5H15.1V1.2h22.7V128.5z',
       },
     });
-    const orderType = ref(undefined);
     const sortKey = ref('');
     const finishedMounting = ref(false);
     const showIntNodeVis = computed(() => store.state.showIntNodeVis);
@@ -198,7 +197,12 @@ export default defineComponent({
       if (network.value === null) { return; }
 
       let order;
-      sortKey.value = type;
+      if (sortKey.value === type) {
+        sortKey.value = '';
+      } else {
+        sortKey.value = type;
+      }
+
       if (
         type === 'clusterSpectral'
         || type === 'clusterBary'
@@ -470,7 +474,6 @@ export default defineComponent({
       hoverEdge,
       unHoverEdge,
       aggregated,
-      orderType,
       sort,
       matrix,
       cellColorScale,
@@ -484,6 +487,7 @@ export default defineComponent({
       iconMeta,
       selectedNodes,
       clickedNeighborClass,
+      sortKey,
     };
   },
 
@@ -528,7 +532,7 @@ export default defineComponent({
               </text>
               <path
                 :d="icons[icon.iconName].d"
-                :fill="icon.sortName === orderType ? '#EBB769' : '#8B8B8B'"
+                :fill="icon.sortName === sortKey ? '#EBB769' : '#8B8B8B'"
                 transform="scale(0.1)translate(-195,-320)"
                 style="pointer-events: none;"
               />
@@ -568,7 +572,7 @@ export default defineComponent({
                 class="sortIcon"
                 :d="icons.cellSort.d"
                 :transform="`scale(${1 / sortIconScaleFactor})translate(${15 * sortIconScaleFactor},${((cellSize - sortIconWidth) / 2) * sortIconScaleFactor})rotate(90)`"
-                :fill="node === orderType ? '#EBB769' : '#8B8B8B'"
+                :fill="node._id === sortKey ? '#EBB769' : '#8B8B8B'"
                 @click="sort(node._id)"
               />
             </g>

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -194,7 +194,7 @@ export default defineComponent({
       event.preventDefault();
     }
 
-    function sortObserver(type: string, isNode = false) {
+    function changeOrder(type: string, isNode = false) {
       if (network.value === null) { return; }
 
       let order;
@@ -275,10 +275,6 @@ export default defineComponent({
         });
       }
       sortOrder.value = order;
-    }
-
-    function changeOrder(type: string, node: boolean) {
-      sortObserver(type, node);
     }
 
     function sort(order: string): void {

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -539,7 +539,7 @@ export default defineComponent({
             <g
               v-for="node, i of network.nodes"
               :key="`${node._id}_col`"
-              :transform="`translate(${orderingScale(i)})rotate(-90)`"
+              :transform="`translate(${i * cellSize})rotate(-90)`"
               class="column"
               :class="clickedNeighborClass(node)"
             >
@@ -626,7 +626,7 @@ export default defineComponent({
                 <rect
                   v-for="cell in matrix[i]"
                   :key="cell.cellName"
-                  :x="orderingScale(cell.x) + 1"
+                  :x="(cell.x * cellSize) + 1"
                   y="1"
                   :width="cellSize - 2"
                   :height="cellSize - 2"

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -517,6 +517,7 @@ export default defineComponent({
                 fill="white"
                 stroke="gray"
                 stroke-width="1"
+                cursor="pointer"
                 @click="sort(icon.sortName)"
               />
               <text

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -517,14 +517,16 @@ export default defineComponent({
               <rect
                 :width="visMargins.left - 5"
                 height="15"
-                fill="none"
+                fill="white"
                 stroke="gray"
                 stroke-width="1"
+                @click="sort(icon.sortName)"
               />
               <text
                 x="27"
                 y="10"
                 font-size="11"
+                style="pointer-events: none;"
               >
                 {{ icon.text }}
               </text>
@@ -532,6 +534,7 @@ export default defineComponent({
                 :d="icons[icon.iconName].d"
                 :fill="icon.sortName === orderType ? '#EBB769' : '#8B8B8B'"
                 transform="scale(0.1)translate(-195,-320)"
+                style="pointer-events: none;"
               />
             </g>
 


### PR DESCRIPTION
### Does this PR close any open issues?
Depends on #391 
Closes #259
Closes #260 

### Give a longer description of what this PR addresses and why it's needed
Fixes matrix sorting. You can now sort by node, cluster, etc.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] Fix lineup sorting. I need to figure out how to make the lineup order change and how to get changes from lineup back to the store. (#260, might close after)
- [x] Check that sorting twice causes reset
- [x] Check if this fixes #294 (it does not)
- [x] Fix lineup highlighting and selection (needs translation through the `sortOrder` array)
- [x] Make lineup sort not persistent when sorting in matrix (#397)
- [x] Open an issue for lineup grouping matching the matrix (#398)