### PR TITLE
Fix some aggregated network bugs

### DIFF
--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -24,7 +24,14 @@ export default defineComponent({
   setup() {
     // Template objects
     const showMenu = ref(false);
-    const aggregateBy = ref(undefined);
+    const aggregateBy = computed({
+      get() {
+        return store.state.aggregatedBy;
+      },
+      set(value: string | undefined) {
+        store.commit.setAggregatedBy(value);
+      },
+    });
     const directionalEdges = computed({
       get() {
         return store.state.directionalEdges;
@@ -204,11 +211,6 @@ export default defineComponent({
     watchEffect(() => updateLegend(cellColorScale.value, 'unAggr'));
     watchEffect(() => updateLegend(parentColorScale.value, 'parent'));
     watchEffect(() => updateLegend(intTableColorScale.value, 'intTable'));
-    watchEffect(() => {
-      if (!aggregated.value) {
-        aggregateBy.value = undefined;
-      }
-    });
     watch(aggregated, () => {
       if (!aggregated.value) {
         labelVariable.value = '_key';

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -170,6 +170,14 @@ export default defineComponent({
             lineupIsSorter = true;
           }
         });
+
+        lineup.value.data.getFirstRanking().on('groupsChanged', (oldSortOrder: number[], newSortOrder: number[], oldGroups: { name: string }[], newGroups: { name: string }[]) => {
+          if (JSON.stringify(oldGroups.map((group) => group.name)) !== JSON.stringify(newGroups.map((group) => group.name))) {
+            if (lineup.value !== null && lineup.value.data.getFirstRanking().getGroupCriteria().length > 0) {
+              store.dispatch.aggregateNetwork(lineup.value.data.getFirstRanking().getGroupCriteria()[0].desc.column);
+            }
+          }
+        });
       }
     }
 

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -3,7 +3,9 @@ import store from '@/store';
 import {
   computed, defineComponent, onMounted, Ref, ref, watch, watchEffect,
 } from '@vue/composition-api';
-import LineUp, { Column, DataBuilder, LocalDataProvider } from 'lineupjs';
+import LineUp, {
+  Column, DataBuilder, IBuilderAdapterColumnDescProps, LocalDataProvider,
+} from 'lineupjs';
 import { select } from 'd3-selection';
 import { isInternalField } from '@/lib/typeUtils';
 import vuetify from '@/plugins/vuetify';
@@ -174,7 +176,8 @@ export default defineComponent({
         lineup.value.data.getFirstRanking().on('groupsChanged', (oldSortOrder: number[], newSortOrder: number[], oldGroups: { name: string }[], newGroups: { name: string }[]) => {
           if (JSON.stringify(oldGroups.map((group) => group.name)) !== JSON.stringify(newGroups.map((group) => group.name))) {
             if (lineup.value !== null && lineup.value.data.getFirstRanking().getGroupCriteria().length > 0) {
-              store.dispatch.aggregateNetwork(lineup.value.data.getFirstRanking().getGroupCriteria()[0].desc.column);
+              const columnDesc = lineup.value.data.getFirstRanking().getGroupCriteria()[0].desc as IBuilderAdapterColumnDescProps;
+              store.dispatch.aggregateNetwork(columnDesc.column);
             }
           }
         });

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -100,17 +100,6 @@ export default defineComponent({
       .domain(sortOrder.value)
       .range([0, sortOrder.value.length * cellSize.value]));
     const hoveredNodes = computed(() => store.state.hoveredNodes);
-    const idMap = computed(() => {
-      const computedIdMap: { [key: string]: number } = {};
-
-      if (network.value !== null) {
-        network.value.nodes.forEach((node: Node, index: number) => {
-          computedIdMap[node._id] = index;
-        });
-      }
-
-      return computedIdMap;
-    });
     const showTable = computed({
       get() {
         return store.state.showPathTable;
@@ -321,6 +310,14 @@ export default defineComponent({
       let maxAggrConnections = 0;
       matrix.value = [];
 
+      const idMap: { [key: string]: number } = {};
+
+      if (network.value !== null) {
+        network.value.nodes.forEach((node: Node, index: number) => {
+          idMap[node._id] = index;
+        });
+      }
+
       if (network.value !== null) {
         network.value.nodes.forEach((rowNode: Node, i: number) => {
           if (network.value !== null) {
@@ -340,10 +337,10 @@ export default defineComponent({
 
         // Count occurrences of edges and store it in the matrix
         network.value.edges.forEach((edge: Edge) => {
-          matrix.value[idMap.value[edge._from]][idMap.value[edge._to]].z += 1;
+          matrix.value[idMap[edge._from]][idMap[edge._to]].z += 1;
 
           if (!directionalEdges.value) {
-            matrix.value[idMap.value[edge._to]][idMap.value[edge._from]].z += 1;
+            matrix.value[idMap[edge._to]][idMap[edge._from]].z += 1;
           }
         });
       }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -570,6 +570,7 @@ const {
       commit.setNetwork(payload.network);
       commit.setSortOrder(range(0, payload.network.nodes.length));
       commit.setSlicedNetwork([]);
+      defineNeighbors(payload.network.nodes, payload.network.edges);
     },
 
     async fetchUserInfo(context) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -633,23 +633,10 @@ const {
       if (state.network !== null) {
         // Reset network if aggregated
         if (state.aggregated && varName === undefined) {
-          // Reset an aggregated network
-          const allChildren = state.network.nodes
-            .map((node) => node.children)
-            .flat()
-            .filter((node): node is Node => node !== undefined);
-
-          const originalEdges = state.network.edges.map((edge) => {
-            const originalEdge = { ...edge };
-            originalEdge._from = `${originalEdge.originalFrom}`;
-            originalEdge._to = `${originalEdge.originalTo}`;
-
-            return originalEdge;
-          });
-
+          const unAggregatedNetwork = state.networkOnLoad !== null ? structuredClone(state.networkOnLoad) : { nodes: [], edges: [] };
           store.commit.setAggregated(false);
-          store.commit.setNetworkPreFilter({ nodes: allChildren, edges: originalEdges });
-          dispatch.updateNetwork({ network: { nodes: allChildren, edges: originalEdges } });
+          store.commit.setNetworkPreFilter(unAggregatedNetwork);
+          dispatch.updateNetwork({ network: unAggregatedNetwork });
         }
 
         // Aggregate the network if the varName is not none

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -363,7 +363,7 @@ const {
     },
 
     setNetworkOnLoad(state, network: Network) {
-      state.networkOnLoad = network;
+      state.networkOnLoad = structuredClone(network);
     },
 
     setSelected(state, selectedNodes: Set<string>) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -47,6 +47,7 @@ const {
     selectNeighbors: true,
     showGridLines: true,
     aggregated: false,
+    aggregatedBy: undefined,
     visualizedNodeAttributes: [],
     visualizedEdgeAttributes: [],
     maxConnections: {
@@ -252,6 +253,10 @@ const {
       const degreeObject = setNodeDegreeDict(store.state.networkPreFilter, store.state.networkOnLoad, store.state.connectivityMatrixPaths.paths.length > 0, store.state.directionalEdges);
       state.maxDegree = degreeObject.maxDegree;
       state.nodeDegreeDict = degreeObject.nodeDegreeDict;
+    },
+
+    setAggregatedBy(state, varName: string | undefined) {
+      state.aggregatedBy = varName;
     },
 
     setQueriedNetworkState(state, queried: boolean) {
@@ -631,6 +636,8 @@ const {
       const { state, commit, dispatch } = rootActionContext(context);
 
       if (state.network !== null) {
+        store.commit.setAggregatedBy(varName);
+
         // Reset network if aggregated
         if (state.aggregated && varName === undefined) {
           const unAggregatedNetwork = state.networkOnLoad !== null ? structuredClone(state.networkOnLoad) : { nodes: [], edges: [] };

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,7 @@ export interface State {
   selectNeighbors: boolean;
   showGridLines: boolean;
   aggregated: boolean;
+  aggregatedBy: string | undefined;
   maxConnections: {
     unAggr: number;
     parent: number;


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #314
Closes #399
Closes #402 
Closes #404 

### Give a longer description of what this PR addresses and why it's needed
This PR fixes a small issue with the legend count after aggregating, allows aggregating from lineup, and fixes aggregated neighbor highlighting.

The issue with legend counts was an easy fix that just required cloning the network as it was saved on load and read again to aggregate and reset the network.

To allow aggregation from lineup, we watch for that event and trigger a global aggregation, which clears out the lineup and matrix and loads the new network.

To fix the neighbor highlight, I was going to do something complicated with searching through children, etc., but we just need to recompute neighbors when the network expands/retracts. Since the edges are correct, that fixes things up.


### Provide pictures/videos of the behavior before and after these changes (optional)
There are no real UI changes. The buttons/highlights just work now

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] Fix neighbor highlighting issue #314 
- [x] See if nested sorting is possible (will address in a follow up)
