### PR TITLE
Remove cycles from connectivity queries

### DIFF
--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -400,6 +400,11 @@ export default defineComponent({
           currentString += `LET start_nodes = (FOR n0 in [${store.getters.nodeTableNames}][**] FILTER 1==1 `;
         } else if (!thisRoundIsNode) {
           currentString += `FOR n${nodeOrEdgeNum + 1}, e${nodeOrEdgeNum + 1} IN 1..1 ANY n${nodeOrEdgeNum} GRAPH '${store.state.networkName}' FILTER 1==1 `;
+
+          // If we have any node with nX where X is greater than 2, make sure we're not making cycles
+          if (nodeOrEdgeNum > 1) {
+            currentString += `n${nodeOrEdgeNum} != n${nodeOrEdgeNum - 2} `;
+          }
         }
 
         // Loop through each query piece

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -406,7 +406,7 @@ export default defineComponent({
             currentString += `AND n${nodeOrEdgeNum + 1} != n${nodeOrEdgeNum - 1} `;
           }
 
-          // If we have any node with nX where X is greater than 3, make sure we're not making 3 hopcycles
+          // If we have any node with nX where X is greater than 3, make sure we're not making 3 hop cycles
           if (nodeOrEdgeNum + 1 > 2) {
             currentString += `AND n${nodeOrEdgeNum + 1} != n${nodeOrEdgeNum - 2} `;
           }

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -402,8 +402,8 @@ export default defineComponent({
           currentString += `FOR n${nodeOrEdgeNum + 1}, e${nodeOrEdgeNum + 1} IN 1..1 ANY n${nodeOrEdgeNum} GRAPH '${store.state.networkName}' FILTER 1==1 `;
 
           // If we have any node with nX where X is greater than 2, make sure we're not making cycles
-          if (nodeOrEdgeNum > 1) {
-            currentString += `AND n${nodeOrEdgeNum} != n${nodeOrEdgeNum - 2} `;
+          if (nodeOrEdgeNum + 1 > 1) {
+            currentString += `AND n${nodeOrEdgeNum + 1} != n${nodeOrEdgeNum - 1} `;
           }
         }
 

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -401,9 +401,14 @@ export default defineComponent({
         } else if (!thisRoundIsNode) {
           currentString += `FOR n${nodeOrEdgeNum + 1}, e${nodeOrEdgeNum + 1} IN 1..1 ANY n${nodeOrEdgeNum} GRAPH '${store.state.networkName}' FILTER 1==1 `;
 
-          // If we have any node with nX where X is greater than 2, make sure we're not making cycles
+          // If we have any node with nX where X is greater than 2, make sure we're not making 2-cycles
           if (nodeOrEdgeNum + 1 > 1) {
             currentString += `AND n${nodeOrEdgeNum + 1} != n${nodeOrEdgeNum - 1} `;
+          }
+
+          // If we have any node with nX where X is greater than 3, make sure we're not making 3-cycles
+          if (nodeOrEdgeNum + 1 > 2) {
+            currentString += `AND n${nodeOrEdgeNum + 1} != n${nodeOrEdgeNum - 2} `;
           }
         }
 

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -401,12 +401,12 @@ export default defineComponent({
         } else if (!thisRoundIsNode) {
           currentString += `FOR n${nodeOrEdgeNum + 1}, e${nodeOrEdgeNum + 1} IN 1..1 ANY n${nodeOrEdgeNum} GRAPH '${store.state.networkName}' FILTER 1==1 `;
 
-          // If we have any node with nX where X is greater than 2, make sure we're not making 2-cycles
+          // If we have any node with nX where X is greater than 2, make sure we're not making 2 hop cycles
           if (nodeOrEdgeNum + 1 > 1) {
             currentString += `AND n${nodeOrEdgeNum + 1} != n${nodeOrEdgeNum - 1} `;
           }
 
-          // If we have any node with nX where X is greater than 3, make sure we're not making 3-cycles
+          // If we have any node with nX where X is greater than 3, make sure we're not making 3 hopcycles
           if (nodeOrEdgeNum + 1 > 2) {
             currentString += `AND n${nodeOrEdgeNum + 1} != n${nodeOrEdgeNum - 2} `;
           }

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -263,6 +263,13 @@
           </v-card>
 
           <v-list-item>
+            <v-switch
+              v-model="sameStartEnd"
+              label="Allow same start and end node in path"
+            />
+          </v-list-item>
+
+          <v-list-item>
             <v-btn
               block
               class="mb-2"
@@ -318,6 +325,7 @@ export default defineComponent({
     const selectedQueryOptions: Ref<string[]> = ref([]);
     const queryOptionItems = ['==', '=~', '!=', '<', '<=', '>', '>='];
     const operatorOptionItems = ['AND', 'OR', 'NOT'];
+    const sameStartEnd = ref(false);
 
     const directionalEdges = computed({
       get() {
@@ -402,12 +410,13 @@ export default defineComponent({
           currentString += `FOR n${nodeOrEdgeNum + 1}, e${nodeOrEdgeNum + 1} IN 1..1 ANY n${nodeOrEdgeNum} GRAPH '${store.state.networkName}' FILTER 1==1 `;
 
           // If we have any node with nX where X is greater than 2, make sure we're not making 2 hop cycles
-          if (nodeOrEdgeNum + 1 > 1) {
+          const lastNode = nodeOrEdgeNum + 1 === selectedHops.value;
+          if (nodeOrEdgeNum + 1 > 1 && (selectedHops.value !== 2 || !lastNode || !sameStartEnd.value)) {
             currentString += `AND n${nodeOrEdgeNum + 1} != n${nodeOrEdgeNum - 1} `;
           }
 
           // If we have any node with nX where X is greater than 3, make sure we're not making 3 hop cycles
-          if (nodeOrEdgeNum + 1 > 2) {
+          if (nodeOrEdgeNum + 1 > 2 && (selectedHops.value !== 3 || !lastNode || !sameStartEnd.value)) {
             currentString += `AND n${nodeOrEdgeNum + 1} != n${nodeOrEdgeNum - 2} `;
           }
         }
@@ -595,6 +604,7 @@ export default defineComponent({
       operatorOptionItems,
       edgeMutexs,
       dialog,
+      sameStartEnd,
     };
   },
 });

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -403,7 +403,7 @@ export default defineComponent({
 
           // If we have any node with nX where X is greater than 2, make sure we're not making cycles
           if (nodeOrEdgeNum > 1) {
-            currentString += `n${nodeOrEdgeNum} != n${nodeOrEdgeNum - 2} `;
+            currentString += `AND n${nodeOrEdgeNum} != n${nodeOrEdgeNum - 2} `;
           }
         }
 

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -422,7 +422,7 @@ export default defineComponent({
           if (queryPiece.label === '') {
             currentString += '1==1 ';
           } else {
-            let property = thisRoundIsNode ? `n${nodeOrEdgeNum}.${queryPiece.label}` : `e${nodeOrEdgeNum + 1}.${queryPiece.label}`;
+            let property = thisRoundIsNode ? `n${nodeOrEdgeNum}.\`${queryPiece.label}\`` : `e${nodeOrEdgeNum + 1}.\`${queryPiece.label}\``;
             property = isTextComparison(queryPiece.operator) ? `UPPER(${property})` : `TO_NUMBER(${property})`;
             const value = isTextComparison(queryPiece.operator) ? `UPPER('${queryPiece.input}')` : `TO_NUMBER(${queryPiece.input})`;
             currentString += `${property} ${queryPiece.operator} ${value} `;


### PR DESCRIPTION
### Does this PR close any open issues?
No
Found here and potentially before: https://github.com/multinet-app/multimatrix/pull/409#pullrequestreview-1034719675

### Give a longer description of what this PR addresses and why it's needed
Removes the cycles from the connectivity query. This should stop the start and end node being the same in multi hops. I have removed all 2 hop and 3 hop cycles. These are the only ones that can be present with our current number of hops (max = 3).

I also fixed an issue with the node/edge attribute selection in the query. Previously we would select `n1.attribute`, but for some variable names that causes problems. I've updated it so we select ```n1.`attribute` ```

### Provide pictures/videos of the behavior before and after these changes (optional)
Changes are in the query so will change query results, but there are no UI changes.

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] Check for 3 hop cycles, 4 hop cycles, etc.
- [x] Test that Crystal's broken query now works
- [x] Allow same start and end nodes
- [x] Why is the legend broken? (weird local dev bug)