### PR TITLE
Make matrix and lineup stay in sync when sorting and fix additional sorting related bugs

### DIFF
--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -86,7 +86,7 @@ export default defineComponent({
 
     // Helper functions
     function idsToIndices(ids: string[]) {
-      const sortedData = sortOrder.value.map((i) => (network.value !== null ? network.value.nodes[i] : null));
+      const sortedData = permutingMatrix.map((i) => (network.value !== null ? network.value.nodes[i] : null));
 
       return ids.map((nodeID) => sortedData.findIndex((node) => (node === null ? false : node._id === nodeID)));
     }
@@ -104,7 +104,7 @@ export default defineComponent({
     function indicesToIDs(indices: number[]) {
       if (network.value !== null) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return indices.map((index) => network.value!.nodes[sortOrder.value[index]]._id);
+        return indices.map((index) => network.value!.nodes[permutingMatrix[index]]._id);
       }
       return [];
     }

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -129,18 +129,20 @@ export default defineComponent({
         builder.value = new DataBuilder(network.value.nodes);
 
         // Config adjustments
-        builder.value.dynamicHeight(() => ({
-          defaultHeight: cellSize.value - 2,
-          padding: () => 2,
-          height: () => cellSize.value - 2,
-        }));
+        builder.value
+          .dynamicHeight(() => ({
+            defaultHeight: cellSize.value - 2,
+            padding: () => 2,
+            height: () => cellSize.value - 2,
+          }))
+          .animated(false)
+          .sidePanel(true, true); // enable: true, collapsed: true
 
         // Make the vis
         lineup.value = builder.value
           .deriveColumns(columns)
           .deriveColors()
           .defaultRanking()
-          .sidePanel(true, true) // enable: true, collapsed: true
           .build(lineupDiv);
 
         // Add an event watcher to update selected nodes

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -145,23 +145,6 @@ export default defineComponent({
           .defaultRanking()
           .build(lineupDiv);
 
-        // Add an event watcher to update selected nodes
-        lineup.value.on('selectionChanged', (dataIndices: number[]) => {
-          // Transform data indices to multinet `_id`s
-          const clickedIDs: string[] = indicesToIDs(dataIndices);
-
-          // Find the symmetric difference between the ids here and those in the store
-          function diffFunction<T>(arr1: Array<T>, arr2: Array<T>): Array<T> { return arr1.filter((x) => arr2.indexOf(x) === -1); }
-          let differentIDs = diffFunction<string>(clickedIDs, [...selectedNodes.value.values()])
-            .concat(diffFunction([...selectedNodes.value.values()], clickedIDs));
-
-          // Filter out only the hovered nodes
-          differentIDs = differentIDs.filter((ID) => hoveredNodes.value.indexOf(ID) === -1);
-
-          // Click on the elements that are different to add/remove them from the store
-          differentIDs.forEach((nodeID) => store.dispatch.clickElement(nodeID));
-        });
-
         let lastHovered = '';
 
         // Add an event watcher to update highlighted nodes

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -87,7 +87,15 @@ export default defineComponent({
     const matrixHeight = computed(() => (network.value !== null
       ? network.value.nodes.length * cellSize.value + visMargins.value.top + visMargins.value.bottom
       : 0));
+    let matrixIsSorter = false;
     const sortOrder = computed(() => store.state.sortOrder);
+    watch(sortOrder, () => {
+      if (!matrixIsSorter) {
+        sortKey.value = '';
+      }
+
+      matrixIsSorter = false;
+    });
     const orderingScale = computed(() => scaleBand<number>()
       .domain(sortOrder.value)
       .range([0, sortOrder.value.length * cellSize.value]));
@@ -287,6 +295,7 @@ export default defineComponent({
         });
       }
 
+      matrixIsSorter = true;
       store.commit.setSortOrder(order);
     }
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #401 
Closes #397
Closes #263 (no more crashing)

### Give a longer description of what this PR addresses and why it's needed
This PR addresses a couple of issue that we had with lineup sorting, hovering, and some configuration.

I made the sorting much more robust, while not fully refactoring the code. Lineup now tracks a `permutingMatrix`, which stores lineup's current difference in sort order from the matrix. We need to track this, because when lineup loads with a specific order and is sorted, we need to track the delta. When the matrix is sorted, we can just replace the lineup data so it stays in sync. This approach is much more successful than my previous attempts.

When I added this `permutingMatrix`, it broke the hovering. As a fix, I use the `permutingMatrix` as the map for which nodes are hovered. 

There was also an old function in the lineup component that was supposed to track if multiple rows had been selected. That never worked, because of the way we use selection to hover multiple rows at once (thus taking away our ability to select multiple rows in the lineup). I removed the function for now, since it was conflicting with the hovering logic.

Finally, I grouped all the lineup configuration into one block, and disabled animations, which makes it feel much more snappy.

### Provide pictures/videos of the behavior before and after these changes (optional)
Same as before, sorting just works now.

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] The usual testing