### PR TITLE
Degree filter on large query

### DIFF
--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -569,6 +569,10 @@ export default defineComponent({
             store.commit.setDirectionalEdges(true);
             store.commit.setQueriedNetworkState(true);
             store.commit.setDegreeEntries(setNodeDegreeDict(store.state.networkPreFilter, store.state.networkOnLoad, store.state.queriedNetwork, store.state.directionalEdges));
+            if (promise.length >= 100) {
+              store.commit.setMinDegree(5);
+              store.commit.setDegreeNetwork([5, store.state.maxDegree]);
+            }
           } else {
             // Update state with empty network
             store.dispatch.aggregateNetwork(undefined);

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -88,10 +88,11 @@ export default defineComponent({
     });
     const maxConnections = computed(() => store.state.maxConnections);
     const maxDegree = computed(() => store.state.maxDegree);
-    const degreeRange = ref([0, maxDegree.value]);
+    const minDegree = computed(() => store.state.minDegree);
+    const degreeRange = ref([minDegree.value, maxDegree.value]);
 
-    watch([maxDegree], () => {
-      degreeRange.value = [0, maxDegree.value];
+    watch([maxDegree, minDegree], () => {
+      degreeRange.value = [minDegree.value, maxDegree.value];
     });
 
     // Intermediate node table template objects

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -78,6 +78,7 @@ const {
     selectedHops: 1,
     nodeDegreeDict: {},
     maxDegree: 0,
+    minDegree: 0,
     networkPreFilter: null,
     queriedNetwork: false,
     filteredNetwork: false,
@@ -387,6 +388,10 @@ const {
     setDegreeEntries(state, degreeObject: { maxDegree: number; nodeDegreeDict: {[key: string]: number}}) {
       state.maxDegree = degreeObject.maxDegree;
       state.nodeDegreeDict = degreeObject.nodeDegreeDict;
+    },
+
+    setMinDegree(state, minDegree: number) {
+      state.minDegree = minDegree;
     },
 
     setDegreeNetwork(state, degreeRange: number[]) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,6 +129,7 @@ export interface State {
   selectedHops: number;
   nodeDegreeDict: { [key: string]: number };
   maxDegree: number;
+  minDegree: number;
   networkPreFilter: Network | null;
   queriedNetwork: boolean;
   filteredNetwork: boolean;


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #

### Give a longer description of what this PR addresses and why it's needed
At the moment we don't have any way to display results from queries that are > 100.
Adding a check to see how large the query result is will trigger a filtered matrix.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] Find a semantically meaningful min degree value
- [ ] Change the hover text for filter to show # of children