### PR TITLE
Use autocompletes for != in connectivity query

### DIFF
--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -96,7 +96,7 @@
                         class="pa-1"
                       >
                         <v-autocomplete
-                          v-if="val.operator === '=='"
+                          v-if="val.operator === '==' || val.operator === '!='"
                           v-model="val.input"
                           :items="i % 2 ? edgeAttributeItems[val.label] : nodeAttributeItems[val.label]"
                           clearable
@@ -211,7 +211,7 @@
                           </v-col>
                           <v-col class="pa-1">
                             <v-autocomplete
-                              v-if="val.operator === '=='"
+                              v-if="val.operator === '==' || val.operator === '!='"
                               v-model="val.input"
                               :items="edgeAttributeItems[val.label]"
                               clearable
@@ -382,7 +382,7 @@ function removeField(index: number, field: number, edgeMutex = false) {
 }
 
 function isTextComparison(operator: string) {
-  return ['==', '=~'].includes(operator);
+  return ['==', '!=', '=~'].includes(operator);
 }
 
 function submitQuery() {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #350 

### Give a longer description of what this PR addresses and why it's needed
This PR makes the connectivity query use `v-autocompletes` for `!=` operators.

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://user-images.githubusercontent.com/36867477/185668250-63ca83d7-5e65-43d7-92c1-d6a885aa8262.png)

### Are there any additional TODOs before this PR is ready to go?
No