### PR TITLE
Migrate from vuex to pinia

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,19 +24,18 @@
     "d3-selection": "^2.0.0",
     "d3-svg-legend": "^2.25.6",
     "d3-transition": "^2.0.0",
-    "direct-vuex": "^0.12.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "lineupjs": "^4.2.0",
     "multinet": "^0.21.7",
     "multinet-components": "^0.0.3",
+    "pinia": "^2.0.28",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "reorder.js": "^2.2.5",
     "unplugin-vue-components": "^0.22.12",
     "vite": "^4.0.2",
     "vue": "^2.7.0",
-    "vuetify": "^2.6.10",
-    "vuex": "^3.6.0"
+    "vuetify": "^2.6.10"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.30.5",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,41 +1,41 @@
 <script setup lang="ts">
 import AlertBanner from '@/components/AlertBanner.vue';
-import { computed } from 'vue';
 import ProvVis from '@/components/ProvVis.vue';
 import ControlPanel from '@/components/ControlPanel.vue';
 import MultiMatrix from '@/components/MultiMatrix.vue';
 import EdgeSlices from '@/components/EdgeSlices.vue';
 import { getUrlVars } from '@/lib/utils';
-import store from '@/store';
-
+import { useStore } from '@/store';
 import 'multinet-components/dist/style.css';
+import { storeToRefs } from 'pinia';
+
+const store = useStore();
 
 const urlVars = getUrlVars();
 
-store.dispatch.fetchNetwork({
-  workspaceName: urlVars.workspace,
-  networkName: urlVars.network,
-}).then(() => {
-  store.dispatch.createProvenance();
+store.fetchNetwork(
+  urlVars.workspace,
+  urlVars.network,
+).then(() => {
+  store.createProvenance();
 });
-const network = computed(() => store.state.network);
 
-const loadError = computed(() => store.state.loadError);
-
-const showProvenanceVis = computed(() => store.state.showProvenanceVis);
-
-const slicedNetwork = computed(() => store.state.slicedNetwork.length > 1);
-
+const {
+  network,
+  loadError,
+  showProvenanceVis,
+  slicedNetwork,
+} = storeToRefs(store);
 </script>
 
 <template>
   <v-app>
     <v-main>
       <control-panel />
-      <edge-slices
-        v-if="network !== null && slicedNetwork"
-      />
-      <multi-matrix v-if="network !== null" />
+
+      <edge-slices v-if="slicedNetwork.length > 0" />
+
+      <multi-matrix v-if="network.nodes.length > 0" />
 
       <alert-banner v-if="loadError.message !== ''" />
     </v-main>

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -166,7 +166,7 @@
               <div v-show="showSecondEdge && i === 1">
                 <v-list dense>
                   <v-list-item
-                    v-for="(val, k) in edgeMutexs.value"
+                    v-for="(val, k) in edgeMutexes.value"
                     :key="`val-${i}-2-${k}`"
                     class="pa-0"
                   >
@@ -179,7 +179,7 @@
                           >
                             <v-autocomplete
                               v-if="k > 0"
-                              v-model="edgeMutexs.operator"
+                              v-model="edgeMutexes.operator"
                               :items="operatorOptionItems"
                               clearable
                               dense
@@ -293,7 +293,7 @@ import {
   Node, Edge, Network, ArangoPath,
 } from '@/types';
 import {
-  computed, onMounted, ref, Ref, watch,
+  computed, onMounted, ref, watch,
 } from 'vue';
 import api from '@/api';
 import { defineNeighbors, setNodeDegreeDict } from '@/lib/utils';
@@ -323,15 +323,15 @@ const {
 const showSecondEdge = ref(false);
 const hopsSelection = [1, 2, 3];
 const displayedHops = computed(() => 2 * selectedHops.value + 1);
-const loading: Ref<boolean> = ref(false);
+const loading = ref(false);
 
 const queryOptionItems = ['==', '=~', '!=', '<', '<=', '>', '>='];
 const operatorOptionItems = ['AND', 'OR', 'NOT'];
 const sameStartEnd = ref(false);
 
 // Create the object for storing input data
-const queryInput: Ref<{ key: number; value: { label: string; operator: string; input: string }[]; operator: string }[]> = ref([]);
-const edgeMutexs: Ref<{ value: { label: string; operator: string; input: string }[]; operator: string }> = ref({ value: [], operator: '' });
+const queryInput = ref<{ key: number; value: { label: string; operator: string; input: string }[]; operator: string }[]>([]);
+const edgeMutexes = ref<{ value: { label: string; operator: string; input: string }[]; operator: string }>({ value: [], operator: '' });
 
 function resetDefaultValues() {
   queryInput.value = [...Array(displayedHops.value).keys()].map((i: number) => {
@@ -351,11 +351,11 @@ function resetDefaultValues() {
   });
 
   if (workspaceName.value === 'marclab') {
-    edgeMutexs.value = {
+    edgeMutexes.value = {
       value: [{ label: 'Type', operator: '=~', input: '' }], operator: '',
     };
   } else {
-    edgeMutexs.value = {
+    edgeMutexes.value = {
       value: [{ label: '', operator: '=~', input: '' }], operator: '',
     };
   }
@@ -367,7 +367,7 @@ onMounted(() => resetDefaultValues());
 
 function addField(index: number, edgeMutex = false) {
   if (edgeMutex) {
-    edgeMutexs.value.value.push({ input: '', label: '', operator: '=~' });
+    edgeMutexes.value.value.push({ input: '', label: '', operator: '=~' });
   } else {
     queryInput.value[index].value.push({ input: '', label: '', operator: '=~' });
   }
@@ -375,7 +375,7 @@ function addField(index: number, edgeMutex = false) {
 
 function removeField(index: number, field: number, edgeMutex = false) {
   if (edgeMutex) {
-    edgeMutexs.value.value.splice(field, 1);
+    edgeMutexes.value.value.splice(field, 1);
   } else {
     queryInput.value[index].value.splice(field, 1);
   }
@@ -453,8 +453,8 @@ function submitQuery() {
         currentString += `RETURN n0) \nLET excluded_pairs = UNIQUE(FOR n0 in start_nodes FOR n1, e1, p1 IN 1..1 ANY n0 GRAPH \`${networkName.value}\` FILTER (`;
 
         // Add mutual exclusion filters
-        const { operator } = edgeMutexs.value;
-        edgeMutexs.value.value.forEach((queryPiece, index) => {
+        const { operator } = edgeMutexes.value;
+        edgeMutexes.value.value.forEach((queryPiece, index) => {
           if (index !== 0) {
             currentString += `${operator} `;
           }

--- a/src/components/ConnectivityQuery.vue
+++ b/src/components/ConnectivityQuery.vue
@@ -98,7 +98,7 @@
                         <v-autocomplete
                           v-if="val.operator === '==' || val.operator === '!='"
                           v-model="val.input"
-                          :items="i % 2 ? edgeAttributeItems[val.label] : nodeAttributeItems[val.label]"
+                          :items="i % 2 ? edgeAttributes[val.label] : nodeAttributes[val.label]"
                           clearable
                           dense
                         />
@@ -213,7 +213,7 @@
                             <v-autocomplete
                               v-if="val.operator === '==' || val.operator === '!='"
                               v-model="val.input"
-                              :items="edgeAttributeItems[val.label]"
+                              :items="edgeAttributes[val.label]"
                               clearable
                               dense
                             />
@@ -288,7 +288,7 @@
 </template>
 
 <script setup lang="ts">
-import store from '@/store';
+import { useStore } from '@/store';
 import {
   Node, Edge, Network, ArangoPath,
 } from '@/types';
@@ -297,37 +297,37 @@ import {
 } from 'vue';
 import api from '@/api';
 import { defineNeighbors, setNodeDegreeDict } from '@/lib/utils';
+import { storeToRefs } from 'pinia';
+
+const store = useStore();
+const {
+  selectedHops,
+  nodeVariableItems,
+  edgeVariableItems,
+  nodeAttributes,
+  edgeAttributes,
+  directionalEdges,
+  networkName,
+  workspaceName,
+  nodeTableNames,
+  loadError,
+  connectivityMatrixPaths,
+  showIntNodeVis,
+  networkPreFilter,
+  queriedNetwork,
+  networkOnLoad,
+  maxDegree,
+  nodeDegreeDict,
+} = storeToRefs(store);
 
 const showSecondEdge = ref(false);
 const hopsSelection = [1, 2, 3];
-const selectedHops = computed({
-  get() {
-    return store.state.selectedHops;
-  },
-  set(value: number) {
-    store.commit.setSelectedHops(value);
-  },
-});
 const displayedHops = computed(() => 2 * selectedHops.value + 1);
 const loading: Ref<boolean> = ref(false);
-
-const nodeVariableItems = computed(() => store.getters.nodeVariableItems);
-const edgeVariableItems = computed(() => store.getters.edgeVariableItems);
-const nodeAttributeItems = computed(() => store.state.nodeAttributes);
-const edgeAttributeItems = computed(() => store.state.edgeAttributes);
 
 const queryOptionItems = ['==', '=~', '!=', '<', '<=', '>', '>='];
 const operatorOptionItems = ['AND', 'OR', 'NOT'];
 const sameStartEnd = ref(false);
-
-const directionalEdges = computed({
-  get() {
-    return store.state.directionalEdges;
-  },
-  set(value: boolean) {
-    store.commit.setDirectionalEdges(value);
-  },
-});
 
 // Create the object for storing input data
 const queryInput: Ref<{ key: number; value: { label: string; operator: string; input: string }[]; operator: string }[]> = ref([]);
@@ -335,7 +335,7 @@ const edgeMutexs: Ref<{ value: { label: string; operator: string; input: string 
 
 function resetDefaultValues() {
   queryInput.value = [...Array(displayedHops.value).keys()].map((i: number) => {
-    if (store.state.workspaceName === 'marclab') {
+    if (workspaceName.value === 'marclab') {
       if (i % 2) {
         return {
           key: i, value: [{ label: 'Type', operator: '=~', input: '' }], operator: '',
@@ -350,7 +350,7 @@ function resetDefaultValues() {
     };
   });
 
-  if (store.state.workspaceName === 'marclab') {
+  if (workspaceName.value === 'marclab') {
     edgeMutexs.value = {
       value: [{ label: 'Type', operator: '=~', input: '' }], operator: '',
     };
@@ -398,9 +398,9 @@ function submitQuery() {
     const nodeOrEdgeNum = Math.floor(input.key / 2);
 
     if (input.key === 0) {
-      currentString += `LET start_nodes = (FOR n0 in [\`${store.getters.nodeTableNames}\`][**] FILTER 1==1 `;
+      currentString += `LET start_nodes = (FOR n0 in [\`${nodeTableNames.value}\`][**] FILTER 1==1 `;
     } else if (!thisRoundIsNode) {
-      currentString += `FOR n${nodeOrEdgeNum + 1}, e${nodeOrEdgeNum + 1} IN 1..1 ANY n${nodeOrEdgeNum} GRAPH \`${store.state.networkName}\` FILTER 1==1 `;
+      currentString += `FOR n${nodeOrEdgeNum + 1}, e${nodeOrEdgeNum + 1} IN 1..1 ANY n${nodeOrEdgeNum} GRAPH \`${networkName.value}\` FILTER 1==1 `;
 
       // If we have any node with nX where X is greater than 2, make sure we're not making 2 hop cycles
       const lastNode = nodeOrEdgeNum + 1 === selectedHops.value;
@@ -450,7 +450,7 @@ function submitQuery() {
     if (input.key === 0) {
       // Add mutual exclusion query line
       if (showSecondEdge.value) {
-        currentString += `RETURN n0) \nLET excluded_pairs = UNIQUE(FOR n0 in start_nodes FOR n1, e1, p1 IN 1..1 ANY n0 GRAPH \`${store.state.networkName}\` FILTER (`;
+        currentString += `RETURN n0) \nLET excluded_pairs = UNIQUE(FOR n0 in start_nodes FOR n1, e1, p1 IN 1..1 ANY n0 GRAPH \`${networkName.value}\` FILTER (`;
 
         // Add mutual exclusion filters
         const { operator } = edgeMutexs.value;
@@ -486,15 +486,15 @@ function submitQuery() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let newAQLNetwork: Promise<any[]> | undefined;
   try {
-    newAQLNetwork = api.aql(store.state.workspaceName || '', { query: aqlQuery, bind_vars: {} });
+    newAQLNetwork = api.aql(workspaceName.value || '', { query: aqlQuery, bind_vars: {} });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     // Add error message for user
     if (error.status === 400) {
-      store.commit.setLoadError({
+      loadError.value = {
         message: error.statusText,
         href: 'https://multinet.app',
-      });
+      };
     }
   }
   if (newAQLNetwork !== undefined) {
@@ -550,24 +550,26 @@ function submitQuery() {
         });
 
         // Update state for use in intermediate node vis TODO
-        store.commit.setConnectivityMatrixPaths({ nodes: middleNodesList, paths: reconstructedPaths });
+        connectivityMatrixPaths.value = { nodes: middleNodesList, paths: reconstructedPaths };
 
         // Update state for showing intermediate node vis
-        store.commit.toggleShowIntNodeVis(selectedHops.value > 1);
+        showIntNodeVis.value = selectedHops.value > 1;
 
         // Update state with new network
-        store.dispatch.aggregateNetwork(undefined);
-        store.dispatch.updateNetwork({ network: newNetwork });
-        store.commit.setNetworkPreFilter(newNetwork);
+        store.aggregateNetwork(undefined);
+        store.updateNetwork(newNetwork);
+        networkPreFilter.value = newNetwork;
         loading.value = false;
-        store.commit.setDirectionalEdges(true);
-        store.commit.setQueriedNetworkState(true);
-        store.commit.setDegreeEntries(setNodeDegreeDict(store.state.networkPreFilter, store.state.networkOnLoad, store.state.queriedNetwork, store.state.directionalEdges));
+        directionalEdges.value = false;
+        queriedNetwork.value = false;
+        const degreeObject = setNodeDegreeDict(networkPreFilter.value, networkOnLoad.value, queriedNetwork.value, directionalEdges.value);
+        maxDegree.value = degreeObject.maxDegree;
+        nodeDegreeDict.value = degreeObject.nodeDegreeDict;
       } else {
         // Update state with empty network
-        store.dispatch.aggregateNetwork(undefined);
-        store.dispatch.updateNetwork({ network: { nodes: [], edges: [] } });
-        store.commit.toggleShowIntNodeVis(false);
+        store.aggregateNetwork(undefined);
+        store.updateNetwork({ nodes: [], edges: [] });
+        showIntNodeVis.value = false;
       }
 
       loading.value = false;

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
-import store from '@/store';
-import { computed } from 'vue';
+import { useStore } from '@/store';
+import { storeToRefs } from 'pinia';
+
+const store = useStore();
+const { rightClickMenu } = storeToRefs(store);
 
 function clearSelection() {
-  store.dispatch.clearSelection();
+  store.clearSelection();
 }
-
-const rightClickMenu = computed(() => store.state.rightClickMenu);
 </script>
 
 <template>

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -4,114 +4,66 @@ import { format } from 'd3-format';
 import { legendColor } from 'd3-svg-legend';
 import { ScaleLinear } from 'd3-scale';
 import { Node, Edge, ArangoPath } from '@/types';
-import store from '@/store';
+import { useStore } from '@/store';
 import AboutDialog from '@/components/AboutDialog.vue';
 import { LoginMenu } from 'multinet-components';
 import ConnectivityQuery from '@/components/ConnectivityQuery.vue';
 import EdgeSlicing from '@/components/EdgeSlicing.vue';
 import {
-  computed, Ref, ref, watch, watchEffect,
+  computed, ref, watch, watchEffect,
 } from 'vue';
 import oauthClient from '@/oauth';
+import { storeToRefs } from 'pinia';
+
+const store = useStore();
+const {
+  aggregatedBy,
+  directionalEdges,
+  selectNeighbors,
+  showGridLines,
+  cellSize,
+  labelVariable,
+  showPathTable,
+  aggregated,
+  filteredNetwork,
+  cellColorScale,
+  parentColorScale,
+  nodeVariableItems,
+  maxConnections,
+  maxDegree,
+  columnTypes,
+  nodeTableNames,
+  showIntNodeVis,
+  intAggregatedBy,
+  maxIntConnections,
+  intTableColorScale,
+  network,
+  networkOnLoad,
+  networkName,
+  connectivityMatrixPaths,
+  showProvenanceVis,
+  selectedNodes,
+  userInfo,
+} = storeToRefs(store);
 
 // Template objects
 const showMenu = ref(false);
-const aggregateBy = computed({
-  get() {
-    return store.state.aggregatedBy;
-  },
-  set(value: string | undefined) {
-    store.commit.setAggregatedBy(value);
-  },
-});
-const directionalEdges = computed({
-  get() {
-    return store.state.directionalEdges;
-  },
-  set(value: boolean) {
-    store.commit.setDirectionalEdges(value);
-  },
-});
-const selectNeighbors = computed({
-  get() {
-    return store.state.selectNeighbors;
-  },
-  set(value: boolean) {
-    store.commit.setSelectNeighbors(value);
-  },
-});
-const showGridLines = computed({
-  get() {
-    return store.state.showGridLines;
-  },
-  set(value: boolean) {
-    store.commit.setShowGridlines(value);
-  },
-});
-const cellSize = computed({
-  get() {
-    return store.state.cellSize;
-  },
-  set(value: number) {
-    store.commit.setCellSize(value);
-  },
-});
-const labelVariable = computed({
-  get() {
-    return store.state.labelVariable;
-  },
-  set(value: string | undefined) {
-    store.commit.setLabelVariable(value);
-  },
-});
-const showTable = computed({
-  get() {
-    return store.state.showPathTable;
-  },
-  set(value: boolean) {
-    store.commit.setShowPathTable(value);
-  },
-});
-const aggregated = computed(() => store.state.aggregated);
-const filtered = computed(() => store.state.filteredNetwork);
-const cellColorScale = computed(() => store.getters.cellColorScale);
-const parentColorScale = computed(() => store.getters.parentColorScale);
-const nodeVariableItems = computed(() => store.getters.nodeVariableItems);
 const aggregationItems = computed(() => {
   // Rebuild column types but just for node columns
-  const nodeColumnTypes = store.state.columnTypes !== null ? Object.fromEntries(Object.entries(store.state.columnTypes).filter(([tableName]) => store.getters.nodeTableNames.includes(tableName))) : {};
+  const nodeColumnTypes = columnTypes.value !== null ? Object.fromEntries(Object.entries(columnTypes.value).filter(([tableName]) => nodeTableNames.value.includes(tableName))) : {};
 
   // Get the varName of all node variables that are type category
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   return Object.values(nodeColumnTypes).map((colTypes) => Object.entries(colTypes).filter(([_, colType]) => colType === 'category').map(([varName, _]) => varName)).flat();
 });
-const maxConnections = computed(() => store.state.maxConnections);
-const maxDegree = computed(() => store.state.maxDegree);
 const degreeRange = ref([0, maxDegree.value]);
 
 watch([maxDegree], () => {
   degreeRange.value = [0, maxDegree.value];
 });
 
-// Intermediate node table template objects
-const showIntNodeVis = computed(() => store.state.showIntNodeVis);
-const intAggregatedBy = computed({
-  get() {
-    return store.state.intAggregatedBy;
-  },
-  set(value: string | undefined) {
-    store.commit.setIntAggregatedBy(value);
-  },
-});
-const maxIntConnections = computed(() => store.state.maxIntConnections);
-const intTableColorScale = computed(() => store.getters.intTableColorScale);
-
-// Non-template objects
-const network = computed(() => store.state.network);
-const networkOnLoad = computed(() => store.state.networkOnLoad);
-
 const searchTerm = ref('');
-const searchErrors: Ref<string[]> = ref([]);
+const searchErrors = ref<string[]>([]);
 const searchItems = computed(() => {
   if (network.value !== null && labelVariable.value !== undefined) {
     return network.value.nodes.map((node) => (node[labelVariable.value || '']));
@@ -148,7 +100,7 @@ function exportNetwork() {
       type: 'text/json',
     }),
   );
-  a.download = `${store.state.networkName}.json`;
+  a.download = `${networkName.value}.json`;
   a.click();
 }
 
@@ -195,9 +147,9 @@ function displayCSVBuilder() {
     });
   }
 
-  store.commit.setConnectivityMatrixPaths({ nodes: [], paths: reconstructedPaths });
-  store.commit.setSelectedConnectivityPaths([...Array(reconstructedPaths.length).keys()]);
-  showTable.value = true;
+  connectivityMatrixPaths.value = { nodes: [], paths: reconstructedPaths };
+  store.setSelectedConnectivityPaths([...Array(reconstructedPaths.length).keys()]);
+  showPathTable.value = true;
 }
 
 watchEffect(() => updateLegend(cellColorScale.value, 'unAggr'));
@@ -208,8 +160,8 @@ watch(aggregated, () => {
     labelVariable.value = '_key';
   }
 });
-watch(aggregateBy, () => {
-  labelVariable.value = aggregateBy.value;
+watch(aggregatedBy, () => {
+  labelVariable.value = aggregatedBy.value;
 });
 watchEffect(() => {
   if (!showIntNodeVis.value) {
@@ -217,20 +169,16 @@ watchEffect(() => {
   }
 });
 
-function toggleProvVis() {
-  store.commit.toggleShowProvenanceVis();
-}
-
 function aggregateNetwork(varName: string) {
-  if (filtered.value) {
-    store.commit.setFilteredNetwork(false);
+  if (filteredNetwork.value) {
+    filteredNetwork.value = false;
     if (networkOnLoad.value !== null) {
-      store.dispatch.updateNetwork({ network: networkOnLoad.value });
+      store.updateNetwork(networkOnLoad.value);
     }
     degreeRange.value = [0, maxDegree.value];
-    store.commit.setDegreeNetwork(degreeRange.value);
+    store.setDegreeNetwork(degreeRange.value);
   }
-  store.dispatch.aggregateNetwork(varName);
+  store.aggregateNetwork(varName);
 }
 
 function search() {
@@ -241,7 +189,11 @@ function search() {
       .map((node) => node._id);
 
     if (nodeIDsToSelect.length > 0) {
-      store.commit.addSelectedNode(nodeIDsToSelect);
+      nodeIDsToSelect.forEach((newNodeId) => {
+        if (!selectedNodes.value.includes(newNodeId)) {
+          selectedNodes.value.push(newNodeId);
+        }
+      });
     } else {
       searchErrors.value.push('Enter a valid node to search');
     }
@@ -249,10 +201,8 @@ function search() {
 }
 
 function removeByDegree() {
-  store.commit.setDegreeNetwork(degreeRange.value);
+  store.setDegreeNetwork(degreeRange.value);
 }
-
-const userInfo = computed(() => store.state.userInfo);
 </script>
 
 <template>
@@ -293,8 +243,8 @@ const userInfo = computed(() => store.state.userInfo);
         <login-menu
           :user-info="userInfo"
           :oauth-client="oauthClient"
-          :logout="store.dispatch.logout"
-          :fetch-user-info="store.dispatch.fetchUserInfo"
+          :logout="store.logout"
+          :fetch-user-info="store.fetchUserInfo"
         />
       </v-toolbar>
 
@@ -340,7 +290,7 @@ const userInfo = computed(() => store.state.userInfo);
           </v-list-item>
           <v-list-item>
             <v-autocomplete
-              v-model="aggregateBy"
+              v-model="aggregatedBy"
               label="Aggregation Variable"
               :items="aggregationItems"
               :hide-details="true"
@@ -438,7 +388,7 @@ const userInfo = computed(() => store.state.userInfo);
               color="primary"
               block
               depressed
-              @click="toggleProvVis"
+              @click="showProvenanceVis = true"
             >
               Provenance Vis
             </v-btn>
@@ -491,7 +441,7 @@ const userInfo = computed(() => store.state.userInfo);
         <div class="pa-4">
           <!-- Aggregated Matrix Legend -->
           <v-list-item
-            v-if="aggregated || filtered"
+            v-if="aggregated || filteredNetwork"
             class="pb-0 px-0"
             style="display: flex; max-height: 50px"
           >

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -160,16 +160,13 @@ watch(aggregated, () => {
     labelVariable.value = '_key';
   }
 });
-watch(aggregatedBy, () => {
-  labelVariable.value = aggregatedBy.value;
-});
 watchEffect(() => {
   if (!showIntNodeVis.value) {
     intAggregatedBy.value = undefined;
   }
 });
 
-function aggregateNetwork(varName: string) {
+function aggregateNetwork(varName: string | null) {
   if (filteredNetwork.value) {
     filteredNetwork.value = false;
     if (networkOnLoad.value !== null) {

--- a/src/components/EdgeSlices.vue
+++ b/src/components/EdgeSlices.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import store from '@/store';
+import { useStore } from '@/store';
 import {
   computed, getCurrentInstance, ref, watch,
 } from 'vue';
@@ -7,12 +7,19 @@ import { max } from 'd3-array';
 import { formatLongDate, formatShortDate } from '@/lib/utils';
 import { format } from 'd3-format';
 import { scaleLinear } from 'd3-scale';
+import { storeToRefs } from 'pinia';
 
-const slicedNetwork = computed(() => store.state.slicedNetwork);
-const isDate = computed(() => store.state.isDate);
+const store = useStore();
+const {
+  slicedNetwork,
+  isDate,
+  controlsWidth,
+  network,
+} = storeToRefs(store);
+
 const isNumeric = computed(() => (slicedNetwork.value[0].category === ''));
 const currentInstance = getCurrentInstance();
-const svgWidth = computed(() => (currentInstance !== null ? currentInstance.proxy.$vuetify.breakpoint.width - store.state.controlsWidth : 0));
+const svgWidth = computed(() => (currentInstance !== null ? currentInstance.proxy.$vuetify.breakpoint.width - controlsWidth.value : 0));
 const rectHeight = ref(20);
 
 const currentSlice = computed(() => {
@@ -44,7 +51,7 @@ watch([timeRangesLength], () => {
 function isSelected(key: number) {
   selectedArray.value.fill(false);
   selectedArray.value[key] = true;
-  store.commit.setNetwork(slicedNetwork.value[key].network);
+  network.value = slicedNetwork.value[key].network;
 }
 
 // Heightscale for numeric attributes
@@ -57,7 +64,6 @@ const tooltipMessage = ref('');
 const toggleTooltip = ref(false);
 const tooltipPosition = ref({ x: 0, y: 0 });
 const tooltipStyle = computed(() => `left: ${tooltipPosition.value.x}px; top: ${tooltipPosition.value.y}px; white-space: pre-line;`);
-const controlsWidth = computed(() => store.state.controlsWidth);
 
 function showTooltip(key: number, event: MouseEvent) {
   tooltipPosition.value = {

--- a/src/components/EdgeSlicing.vue
+++ b/src/components/EdgeSlicing.vue
@@ -2,9 +2,7 @@
 import { formatShortDate } from '@/lib/utils';
 import { useStore } from '@/store';
 import { Edge, SlicedNetwork } from '@/types';
-import {
-  computed, Ref, ref, watch,
-} from 'vue';
+import { computed, ref, watch } from 'vue';
 import { scaleLinear, scaleTime } from 'd3-scale';
 import { storeToRefs } from 'pinia';
 
@@ -22,10 +20,10 @@ const showMenu = ref(false);
 const sliceRules = (value: string) => !Number.isNaN(parseFloat(value)) || 'Please type a number';
 const calMenu = ref([false, false]);
 const isSliced = computed(() => slicedNetwork.value.length === 0);
-const startEdgeVar: Ref<string> = ref('');
-const endEdgeVar: Ref<string> = ref('');
+const startEdgeVar = ref('');
+const endEdgeVar = ref('');
 const edgeSliceNumber = ref(1);
-const inputRange: Ref<(Date | number | string)[]> = ref([]);
+const inputRange = ref<(Date | number | string)[]>([]);
 const isTime = ref(false);
 const isNumeric = ref(true);
 const isValidRange = ref(true);

--- a/src/components/EdgeSlicing.vue
+++ b/src/components/EdgeSlicing.vue
@@ -1,40 +1,41 @@
 <script setup lang="ts">
 import { formatShortDate } from '@/lib/utils';
-import store from '@/store';
+import { useStore } from '@/store';
 import { Edge, SlicedNetwork } from '@/types';
 import {
   computed, Ref, ref, watch,
 } from 'vue';
 import { scaleLinear, scaleTime } from 'd3-scale';
+import { storeToRefs } from 'pinia';
+
+const store = useStore();
+const {
+  network,
+  networkOnLoad,
+  slicedNetwork,
+  isDate,
+  edgeVariableItems,
+  networkName,
+} = storeToRefs(store);
 
 const showMenu = ref(false);
 const sliceRules = (value: string) => !Number.isNaN(parseFloat(value)) || 'Please type a number';
 const calMenu = ref([false, false]);
-const network = computed(() => store.state.network);
-const originalNetwork = computed(() => store.state.networkOnLoad);
-const isSliced = computed(() => store.state.slicedNetwork.length === 0);
+const isSliced = computed(() => slicedNetwork.value.length === 0);
 const startEdgeVar: Ref<string> = ref('');
 const endEdgeVar: Ref<string> = ref('');
 const edgeSliceNumber = ref(1);
 const inputRange: Ref<(Date | number | string)[]> = ref([]);
 const isTime = ref(false);
-const isDate = computed({
-  get() {
-    return store.state.isDate;
-  },
-  set(value: boolean) {
-    return store.commit.setIsDate(value);
-  },
-});
 const isNumeric = ref(true);
 const isValidRange = ref(true);
 
 // Check if selected variable is numeric
 function checkType() {
   // eslint-disable-next-line no-unused-expressions
-  if (originalNetwork.value !== null) {
+  if (networkOnLoad.value !== null) {
     isNumeric.value = !Number.isNaN(
-      parseFloat(`${originalNetwork.value.edges[0][startEdgeVar.value]}`),
+      parseFloat(`${networkOnLoad.value.edges[0][startEdgeVar.value]}`),
     );
   }
 }
@@ -59,18 +60,16 @@ watch([startEdgeVar], () => {
   }
 });
 
-const cleanedEdgeVariables = computed(() => store.getters.edgeVariableItems);
-
 // Compute the min and max times for numbers or date
 const validRange = computed(() => {
   const range: (Date | number | string)[] = [0, 0];
   if (
     startEdgeVar.value !== null
           && endEdgeVar.value !== null
-          && originalNetwork.value !== null
+          && networkOnLoad.value !== null
   ) {
     // Loop through all edges, return min and max time values
-    originalNetwork.value.edges.forEach((edge: Edge, i: number) => {
+    networkOnLoad.value.edges.forEach((edge: Edge, i: number) => {
       // Check for dates
       let startVar: number = parseFloat(`${edge[startEdgeVar.value]}`);
       let endVar: number = parseFloat(`${edge[endEdgeVar.value]}`);
@@ -117,19 +116,19 @@ watch([inputRange], () => {
 function sliceNetwork() {
   // Resets to original network view when variable slice is 1
   if (
-    (originalNetwork.value !== null
+    (networkOnLoad.value !== null
           && edgeSliceNumber.value === 1
           && isNumeric.value)
-        || (originalNetwork.value !== null && startEdgeVar.value === undefined)
+        || (networkOnLoad.value !== null && startEdgeVar.value === undefined)
   ) {
-    store.commit.setSlicedNetwork([]);
-    store.commit.setNetwork(originalNetwork.value);
+    slicedNetwork.value = [];
+    network.value = networkOnLoad.value;
   }
   if (
-    (originalNetwork.value !== null && edgeSliceNumber.value !== 1)
-        || (originalNetwork.value !== null && !isNumeric.value)
+    (networkOnLoad.value !== null && edgeSliceNumber.value !== 1)
+        || (networkOnLoad.value !== null && !isNumeric.value)
   ) {
-    const slicedNetwork: SlicedNetwork[] = [];
+    const newSlicedNetwork: SlicedNetwork[] = [];
     // Generates sliced networks based on time slices or numeric input
     if (isNumeric.value) {
       const slicedRange = [];
@@ -146,7 +145,7 @@ function sliceNetwork() {
         const currentSlice: SlicedNetwork = {
           slice: i + 1,
           time: [],
-          network: { nodes: originalNetwork.value.nodes, edges: [] },
+          network: { nodes: networkOnLoad.value.nodes, edges: [] },
           category: '',
         };
         // Create slices for dates
@@ -158,7 +157,7 @@ function sliceNetwork() {
             timeIntervals.invert(i),
             timeIntervals.invert(i + 1),
           ];
-          originalNetwork.value.edges.forEach((edge: Edge) => {
+          networkOnLoad.value.edges.forEach((edge: Edge) => {
             if (
               timeIntervals(new Date(`${edge[startEdgeVar.value]}`)) >= i
                   && timeIntervals(new Date(`${edge[endEdgeVar.value]}`)) < i + 1
@@ -174,7 +173,7 @@ function sliceNetwork() {
             timeIntervals.invert(i),
             timeIntervals.invert(i + 1),
           ];
-          originalNetwork.value.edges.forEach((edge: Edge) => {
+          networkOnLoad.value.edges.forEach((edge: Edge) => {
             if (
               timeIntervals(parseFloat(`${edge[startEdgeVar.value]}`))
                     >= i
@@ -184,34 +183,34 @@ function sliceNetwork() {
             }
           });
         }
-        slicedNetwork.push(currentSlice);
+        newSlicedNetwork.push(currentSlice);
       }
       // Create slicing for categories
     } else {
       const categoricalValues = new Set(
-        originalNetwork.value.edges.map(
+        networkOnLoad.value.edges.map(
           (edge: Edge) => `${edge[startEdgeVar.value]}`,
         ),
       );
       [...categoricalValues].forEach((attr, i) => {
-        if (originalNetwork.value !== null) {
+        if (networkOnLoad.value !== null) {
           const currentSlice: SlicedNetwork = {
             slice: i + 1,
             time: [],
-            network: { nodes: originalNetwork.value.nodes, edges: [] },
+            network: { nodes: networkOnLoad.value.nodes, edges: [] },
             category: attr,
           };
-          originalNetwork.value.edges.forEach((edge: Edge) => {
+          networkOnLoad.value.edges.forEach((edge: Edge) => {
             if (edge[startEdgeVar.value] === attr) {
               currentSlice.network.edges.push(edge);
             }
           });
-          slicedNetwork.push(currentSlice);
+          newSlicedNetwork.push(currentSlice);
         }
       });
     }
-    store.commit.setSlicedNetwork(slicedNetwork);
-    store.commit.setNetwork(slicedNetwork[0].network);
+    slicedNetwork.value = newSlicedNetwork;
+    network.value = slicedNetwork.value[0].network;
   }
 }
 
@@ -222,12 +221,11 @@ function exportEdges() {
   // Slice network in case 'Generate Slices' button
   // not clicked or updated
   sliceNetwork();
-  const { slicedNetwork } = store.state;
 
   // Generate edge table data
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const edges: any[] = [];
-  slicedNetwork.forEach((slice) => {
+  slicedNetwork.value.forEach((slice) => {
     const timeObj = {
       slice: slice.slice,
       timeStart: slice.time[0],
@@ -263,15 +261,15 @@ function exportEdges() {
       type: 'text/csv',
     }),
   );
-  a.download = `${store.state.networkName}_${edgeSliceNumber.value}-slices.csv`;
+  a.download = `${networkName.value}_${edgeSliceNumber.value}-slices.csv`;
   a.click();
 }
 
 function resetNetwork() {
   // Reset network
-  if (originalNetwork.value !== null) {
-    store.commit.setSlicedNetwork([]);
-    store.commit.setNetwork(originalNetwork.value);
+  if (networkOnLoad.value !== null) {
+    slicedNetwork.value = [];
+    network.value = networkOnLoad.value;
   }
   // Reset form
   startEdgeVar.value = '';
@@ -316,7 +314,7 @@ function resetNetwork() {
           <v-select
             v-model="startEdgeVar"
             :label="isTime ? `Start Variable` : `Edge Variable`"
-            :items="cleanedEdgeVariables"
+            :items="edgeVariableItems"
             :hide-details="true"
             class="mt-3"
             clearable
@@ -329,7 +327,7 @@ function resetNetwork() {
           <v-select
             v-model="endEdgeVar"
             label="End Variable"
-            :items="cleanedEdgeVariables"
+            :items="edgeVariableItems"
             :hide-details="true"
             class="mt-3"
             clearable

--- a/src/components/IntermediaryNodes.vue
+++ b/src/components/IntermediaryNodes.vue
@@ -3,26 +3,25 @@ import { computed } from 'vue';
 import {
   scaleLinear,
 } from 'd3-scale';
-import store from '@/store';
+import { useStore } from '@/store';
 import { ConnectivityCell } from '@/types';
 import { group } from 'd3-array';
+import { storeToRefs } from 'pinia';
 
-const network = computed(() => store.state.network);
-const connectivityPaths = computed(() => store.state.connectivityMatrixPaths);
-const cellSize = computed(() => store.state.cellSize);
-const pathLength = computed(() => connectivityPaths.value.paths[0].vertices.length);
-const edgeLength = computed(() => connectivityPaths.value.paths[0].edges.length);
-const showTable = computed({
-  get() {
-    return store.state.showPathTable;
-  },
-  set(value: boolean) {
-    store.commit.setShowPathTable(value);
-  },
-});
+const store = useStore();
+const {
+  network,
+  connectivityMatrixPaths,
+  cellSize,
+  showPathTable,
+  intAggregatedBy,
+  maxIntConnections,
+} = storeToRefs(store);
+
+const pathLength = computed(() => connectivityMatrixPaths.value.paths[0].vertices.length);
+const edgeLength = computed(() => connectivityMatrixPaths.value.paths[0].edges.length);
 const circleRadius = computed(() => cellSize.value / 2);
 const cellFontSize = computed(() => cellSize.value * 0.8);
-const intAggregatedBy = computed(() => store.state.intAggregatedBy);
 
 const margin = {
   top: 110,
@@ -30,27 +29,27 @@ const margin = {
   bottom: 0,
   left: 40,
 };
-const matrixHeight = computed(() => (connectivityPaths.value.nodes.length > 0 ? connectivityPaths.value.nodes.length * cellSize.value + margin.top + margin.bottom : 0));
+const matrixHeight = computed(() => (connectivityMatrixPaths.value.nodes.length > 0 ? connectivityMatrixPaths.value.nodes.length * cellSize.value + margin.top + margin.bottom : 0));
 
-const intNodeWidth = computed(() => (store.state.connectivityMatrixPaths.nodes.length > 0
+const intNodeWidth = computed(() => (connectivityMatrixPaths.value.nodes.length > 0
   ? margin.left + (pathLength.value + 1) * cellSize.value
   : 0));
-const sortOrder = computed(() => store.state.connectivityMatrixPaths.nodes.map((node) => node._key).sort());
+const sortOrder = computed(() => connectivityMatrixPaths.value.nodes.map((node) => node._key).sort());
 const yScale = computed(() => scaleLinear().domain([0, sortOrder.value.length]).range([0, sortOrder.value.length * cellSize.value]));
-const xScale = computed(() => scaleLinear().domain([0, (edgeLength.value - 1)]).range([0, (connectivityPaths.value.paths[0].edges.length - 1) * cellSize.value]));
+const xScale = computed(() => scaleLinear().domain([0, (edgeLength.value - 1)]).range([0, (connectivityMatrixPaths.value.paths[0].edges.length - 1) * cellSize.value]));
 const hops = computed(() => edgeLength.value - 1);
 const opacity = scaleLinear().domain([0, 0]).range([0, 1]).clamp(true);
 
 const matrixData = computed(() => {
   let matrix: ConnectivityCell[][] = [];
-  if (network.value !== null && connectivityPaths.value.nodes.length > 0) {
-    let sortConnectivityPaths = [];
+  if (network.value !== null && connectivityMatrixPaths.value.nodes.length > 0) {
+    let sortconnectivityMatrixPaths = [];
     const sortKey = intAggregatedBy.value === undefined ? '_key' : intAggregatedBy.value;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sortConnectivityPaths = structuredClone(connectivityPaths.value).nodes.sort((a: any, b: any) => (a[sortKey] > b[sortKey] ? 1 : -1));
+    sortconnectivityMatrixPaths = structuredClone(connectivityMatrixPaths.value).nodes.sort((a: any, b: any) => (a[sortKey] > b[sortKey] ? 1 : -1));
 
     // Set up matrix intermediate nodes x # of hops.value
-    sortConnectivityPaths.forEach((rowNode, i) => {
+    sortconnectivityMatrixPaths.forEach((rowNode, i) => {
       matrix[i] = [...Array(hops.value).keys()].slice(0).map((j) => ({
         cellName: `${rowNode._key}`,
         nodePosition: j + 1,
@@ -67,7 +66,7 @@ const matrixData = computed(() => {
 
     // Set up number of connections based on paths
     // Record associated paths
-    connectivityPaths.value.paths.forEach((path, i) => {
+    connectivityMatrixPaths.value.paths.forEach((path, i) => {
       matrix.forEach((matrixRow) => {
         [...Array(hops.value).keys()].slice(0).forEach((j) => {
           if (path.vertices[j + 1]._key === matrixRow[j].cellName) {
@@ -82,7 +81,8 @@ const matrixData = computed(() => {
   //   Update opacity
   const allPaths = matrix.map((row) => row.map((cell) => cell.z)).flat();
   const maxPath = Math.max(...allPaths);
-  store.commit.setMaxIntConnections(maxPath);
+  // eslint-disable-next-line vue/no-side-effects-in-computed-properties
+  maxIntConnections.value = maxPath;
   opacity.domain([
     0,
     maxPath,
@@ -118,8 +118,8 @@ const matrixData = computed(() => {
 });
 
 function displayTable(paths: number[]) {
-  store.commit.setSelectedConnectivityPaths(paths);
-  showTable.value = true;
+  store.setSelectedConnectivityPaths(paths);
+  showPathTable.value = true;
 }
 </script>
 

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import store from '@/store';
+import { useStore } from '@/store';
 import {
   computed, onMounted, Ref, ref, watch, watchEffect,
 } from 'vue';
@@ -10,11 +10,17 @@ import { select } from 'd3-selection';
 import { isInternalField } from '@/lib/typeUtils';
 import vuetify from '@/plugins/vuetify';
 import WindowInstanceMap from '@/lib/windowSizeUtils';
+import { storeToRefs } from 'pinia';
 
-const network = computed(() => store.state.network);
-const selectedNodes = computed(() => store.state.selectedNodes);
-const hoveredNodes = computed(() => store.state.hoveredNodes);
-const cellSize = computed(() => store.state.cellSize);
+const store = useStore();
+const {
+  network,
+  selectedNodes,
+  hoveredNodes,
+  cellSize,
+  sortOrder,
+  lineupIsNested,
+} = storeToRefs(store);
 
 const lineup: Ref<LineUp | null> = ref(null);
 const builder: Ref<DataBuilder | null> = ref(null);
@@ -48,7 +54,6 @@ const lineupHeight = computed(() => {
 });
 
 let lineupIsSorter = false;
-const sortOrder = computed(() => store.state.sortOrder);
 const lineupOrder = computed(() => {
   if (lineup.value === null || [...lineup.value.data.getFirstRanking().getOrder()].length === 0) {
     return [...Array(network.value?.nodes.length).keys()];
@@ -57,7 +62,7 @@ const lineupOrder = computed(() => {
 });
 
 // If store order has changed, update lineup
-let permutingMatrix = structuredClone(store.state.sortOrder);
+let permutingMatrix = structuredClone(sortOrder.value);
 watch(sortOrder, (newSortOrder) => {
   if (lineup.value !== null && !lineupIsSorter) {
     permutingMatrix = structuredClone(newSortOrder);
@@ -78,7 +83,7 @@ watch(lineupOrder, (newLineupOrder) => {
 
   if (lineup.value !== null && network.value !== null && lineupIsSorter) {
     const newSortOrder = newLineupOrder.map((i) => permutingMatrix[i]);
-    store.commit.setSortOrder(newSortOrder);
+    sortOrder.value = newSortOrder;
   }
 });
 
@@ -155,10 +160,10 @@ function buildLineup() {
       const hoveredIDs: string[] = indicesToIDs([dataIndex]);
 
       // Remove previously hovered node and track what is now hovered
-      store.commit.removeHoveredNode(lastHovered);
+      hoveredNodes.value = hoveredNodes.value.filter((hoveredNode) => hoveredNode !== lastHovered);
 
       // Hover the elements that are different to add/remove them from the store
-      hoveredIDs.forEach((nodeID) => store.commit.pushHoveredNode(nodeID));
+      hoveredIDs.forEach((nodeID) => hoveredNodes.value.push(nodeID));
 
       [lastHovered] = hoveredIDs;
     });
@@ -173,7 +178,7 @@ function buildLineup() {
       if (JSON.stringify(oldGroups.map((group) => group.name)) !== JSON.stringify(newGroups.map((group) => group.name))) {
         if (lineup.value !== null && lineup.value.data.getFirstRanking().getGroupCriteria().length > 0) {
           const columnDesc = lineup.value.data.getFirstRanking().getGroupCriteria()[0].desc as IBuilderAdapterColumnDescProps;
-          store.dispatch.aggregateNetwork(columnDesc.column);
+          store.aggregateNetwork(columnDesc.column);
         }
       }
     });
@@ -182,7 +187,7 @@ function buildLineup() {
 
 watchEffect(() => {
   if (lineup.value !== null) {
-    store.commit.setLineUpIsNested(lineup.value.data.getFirstRanking().flatColumns.map((col: Column) => col.desc.type).includes('nested'));
+    lineupIsNested.value = lineup.value.data.getFirstRanking().flatColumns.map((col: Column) => col.desc.type).includes('nested');
   }
 });
 
@@ -202,7 +207,7 @@ watch(cellSize, () => {
 });
 
 function removeHighlight() {
-  store.commit.clearHoveredNodes();
+  hoveredNodes.value = [];
 }
 </script>
 

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useStore } from '@/store';
 import {
-  computed, onMounted, Ref, ref, watch, watchEffect,
+  computed, onMounted, ref, watch, watchEffect,
 } from 'vue';
 import LineUp, {
   Column, DataBuilder, IBuilderAdapterColumnDescProps, LocalDataProvider,
@@ -22,8 +22,8 @@ const {
   lineupIsNested,
 } = storeToRefs(store);
 
-const lineup: Ref<LineUp | null> = ref(null);
-const builder: Ref<DataBuilder | null> = ref(null);
+const lineup = ref<LineUp | null>(null);
+const builder = ref<DataBuilder | null>(null);
 
 const matrixWidth = ref(0);
 const matrixResizeObserver = new ResizeObserver((a: ResizeObserverEntry[]) => { matrixWidth.value = a[0].target.parentElement?.clientWidth || 0; });

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -16,7 +16,7 @@ import IntermediaryNodes from '@/components/IntermediaryNodes.vue';
 import ContextMenu from '@/components/ContextMenu.vue';
 import * as reorder from 'reorder.js';
 import {
-  computed, onMounted, Ref, ref, watch,
+  computed, onMounted, ref, watch,
 } from 'vue';
 import PathTable from '@/components/PathTable.vue';
 import { storeToRefs } from 'pinia';
@@ -50,9 +50,9 @@ const tooltip = ref(null);
 const visMargins = ref({
   left: 75, top: 110, right: 1, bottom: 1,
 });
-const matrix: Ref<Cell[][]> = ref([]);
+const matrix = ref<Cell[][]>([]);
 const expandedSuperNodes = ref(new Set<string>());
-const icons: Ref<{ [key: string]: { d: string} }> = ref({
+const icons = ref<{ [key: string]: { d: string} }>({
   quant: {
     d:
           'M401,330.7H212c-3.7,0-6.6,3-6.6,6.6v116.4c0,3.7,3,6.6,6.6,6.6h189c3.7,0,6.6-3,6.6-6.6V337.3C407.7,333.7,404.7,330.7,401,330.7z M280,447.3c0,2-1.6,3.6-3.6,3.6h-52.8v-18.8h52.8c2,0,3.6,1.6,3.6,3.6V447.3z M309.2,417.9c0,2-1.6,3.6-3.6,3.6h-82v-18.8h82c2,0,3.6,1.6,3.6,3.6V417.9z M336.4,388.4c0,2-1.6,3.6-3.6,3.6H223.6v-18.8h109.2c2,0,3.6,1.6,3.6,3.6V388.4z M367.3,359c0,2-1.6,3.6-3.6,3.6H223.6v-18.8h140.1c2,0,3.6,1.6,3.6,3.6V359z',

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -44,7 +44,6 @@ const {
   rightClickMenu,
   maxConnections,
   selectedHops,
-  clickedCell,
 } = storeToRefs(store);
 
 const tooltip = ref(null);
@@ -394,7 +393,7 @@ function clickElement(matrixElement: Node | Cell) {
       }
     }
 
-    clickedCell.value = matrixElement.cellName;
+    selectedCell.value = matrixElement.cellName;
   } else {
     store.clickElement(matrixElement._id);
   }

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -101,7 +101,7 @@ function capitalizeFirstLetter(word: string) {
 }
 
 function hoverNode(nodeID: string) {
-  hoveredNodes.value.push(nodeID);
+  hoveredNodes.value = [...hoveredNodes.value, nodeID];
 }
 
 function unHoverNode(nodeID: string) {

--- a/src/components/PathTable.vue
+++ b/src/components/PathTable.vue
@@ -54,7 +54,7 @@
                 >
                   <v-autocomplete
                     v-model="selectedHeader[i]"
-                    :items="i % 2 ? headerEdgeSelections : headerNodeSelections"
+                    :items="i % 2 ? edgeVariableItems : nodeVariableItems"
                     :label="i % 2 ? `Edge ${(i + 1) / 2}: Attribute` : `Node ${(i + 2) / 2}: Attribute`"
                     dense
                     small-chips
@@ -89,18 +89,23 @@
 </template>
 
 <script setup lang="ts">
-import {
-  computed, ref, Ref, watch,
-} from 'vue';
-import store from '@/store';
+import { computed, ref, watch } from 'vue';
+import { useStore } from '@/store';
+import { storeToRefs } from 'pinia';
+
+const store = useStore();
+const {
+  selectedConnectivityPaths,
+  nodeVariableItems,
+  edgeVariableItems,
+  cellSize,
+  network,
+  showPathTable,
+} = storeToRefs(store);
 
 const search = ref('');
-const selectedConnectivityPaths = computed(() => store.state.selectedConnectivityPaths);
 const pathLength = computed(() => selectedConnectivityPaths.value[0].edges.length);
-
-const headerNodeSelections = computed(() => store.getters.nodeVariableItems);
-const headerEdgeSelections = computed(() => store.getters.edgeVariableItems);
-const selectedHeader: Ref<string[][]> = ref([]);
+const selectedHeader = ref<string[][]>([]);
 
 Array(pathLength.value * 2 + 1).fill(1).forEach(() => {
   selectedHeader.value.push(['_key']);
@@ -154,7 +159,7 @@ const tableData = computed(() => {
 });
 
 const top = ref(0);
-const left = ref(store.state.network !== null ? store.state.cellSize * store.state.network.nodes.length + 200 : 0);
+const left = ref(cellSize.value * network.value.nodes.length + 200);
 const divStyle = computed(() => `position: absolute; top: ${top.value}px; left: ${left.value}px; z-index: 1;`);
 function iconDrag(event: MouseEvent) {
   // 24 to account for icon size and padding
@@ -174,7 +179,7 @@ function iconMouseDown(event: MouseEvent) {
 }
 
 function closeCard() {
-  store.commit.setShowPathTable(false);
+  showPathTable.value = false;
 }
 
 function exportPaths() {

--- a/src/components/ProvVis.vue
+++ b/src/components/ProvVis.vue
@@ -1,15 +1,14 @@
 <script setup lang="ts">
 import { ProvVisCreator } from '@visdesignlab/trrack-vis';
-import { ProvenanceEventTypes, State } from '@/types';
-import {
-  computed, ComputedRef, onMounted,
-} from 'vue';
-import store from '@/store';
-import { Provenance } from '@visdesignlab/trrack';
+import { onMounted } from 'vue';
+import { useStore } from '@/store';
+import { storeToRefs } from 'pinia';
 
-const provenance: ComputedRef<Provenance<State, ProvenanceEventTypes, unknown> | null> = computed(
-  () => store.state.provenance,
-);
+const store = useStore();
+const {
+  showProvenanceVis,
+  provenance,
+} = storeToRefs(store);
 
 onMounted(() => {
   const provDiv = document.getElementById('provDiv');
@@ -17,7 +16,7 @@ onMounted(() => {
     ProvVisCreator(
       provDiv,
       provenance.value,
-      (newNode: string) => store.commit.goToProvenanceNode(newNode),
+      (newNode: string) => store.goToProvenanceNode(newNode),
       true,
       true,
       provenance.value.root.id,
@@ -26,7 +25,7 @@ onMounted(() => {
 });
 
 function toggleProvVis() {
-  store.commit.toggleShowProvenanceVis();
+  showProvenanceVis.value = false;
 }
 </script>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,14 +3,18 @@ import App from '@/App.vue';
 import vuetify from '@/plugins/vuetify';
 import api from '@/api';
 import oauthClient from '@/oauth';
+import { createPinia, PiniaVuePlugin } from 'pinia';
 
 Vue.config.productionTip = false;
+Vue.use(PiniaVuePlugin);
+const pinia = createPinia();
 
 oauthClient.maybeRestoreLogin().then(() => {
   Object.assign(api.axios.defaults.headers.common, oauthClient.authHeaders);
 
   new Vue({
     vuetify,
+    pinia,
     render: (h) => h(App),
   }).$mount('#app');
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,11 +1,7 @@
-import Vue from 'vue';
-import Vuex from 'vuex';
-import { createDirectStore } from 'direct-vuex';
-
 import { group, range } from 'd3-array';
 import { scaleLinear, ScaleLinear } from 'd3-scale';
 import { initProvenance, Provenance } from '@visdesignlab/trrack';
-
+import { defineStore } from 'pinia';
 import api from '@/api';
 import oauthClient from '@/oauth';
 import {
@@ -20,26 +16,18 @@ import { defineNeighbors, setNodeDegreeDict } from '@/lib/utils';
 import { undoRedoKeyHandler, updateProvenanceState } from '@/lib/provenanceUtils';
 import { isInternalField } from '@/lib/typeUtils';
 
-Vue.use(Vuex);
-
-const {
-  store,
-  rootActionContext,
-  moduleActionContext,
-  rootGetterContext,
-  moduleGetterContext,
-} = createDirectStore({
-  state: {
-    workspaceName: null,
-    networkName: null,
-    network: null,
+export const useStore = defineStore('store', {
+  state: (): State => ({
+    workspaceName: '',
+    networkName: '',
+    network: { nodes: [], edges: [] },
     loadError: {
       message: '',
       href: '',
     },
     userInfo: null,
     cellSize: 15,
-    selectedNodes: new Set(),
+    selectedNodes: [],
     selectedCell: null,
     hoveredNodes: [],
     sortOrder: [],
@@ -48,8 +36,6 @@ const {
     showGridLines: true,
     aggregated: false,
     aggregatedBy: undefined,
-    visualizedNodeAttributes: [],
-    visualizedEdgeAttributes: [],
     maxConnections: {
       unAggr: 0,
       parent: 0,
@@ -83,30 +69,30 @@ const {
     queriedNetwork: false,
     filteredNetwork: false,
     lineupIsNested: false,
-  } as State,
+  }),
 
   getters: {
-    cellColorScale(state): ScaleLinear<string, number> {
+    cellColorScale(): ScaleLinear<string, number> {
       return scaleLinear<string, number>()
-        .domain([0, state.maxConnections.unAggr])
+        .domain([0, this.maxConnections.unAggr])
         .range(['#feebe2', '#690000']); // TODO: colors here are arbitrary, change later
     },
 
-    parentColorScale(state): ScaleLinear<string, number> {
+    parentColorScale(): ScaleLinear<string, number> {
       return scaleLinear<string, number>()
-        .domain([0, state.maxConnections.parent])
+        .domain([0, this.maxConnections.parent])
         .range(['#dcedfa', '#0066cc']);
     },
 
-    intTableColorScale(state): ScaleLinear<string, number> {
+    intTableColorScale(): ScaleLinear<string, number> {
       return scaleLinear<string, number>()
-        .domain([0, state.maxIntConnections])
+        .domain([0, this.maxIntConnections])
         .range(['white', 'blue']);
     },
 
-    nodeVariableItems(state, getters): string[] {
+    nodeVariableItems(): string[] {
       // Get the name of all columns from the columnTypes
-      let nodeColumnNames: string[] = getters.nodeTableNames.map((nodeTableName: string) => (state.columnTypes !== null ? Object.keys(state.columnTypes[nodeTableName]) : [])).flat();
+      let nodeColumnNames: string[] = this.nodeTableNames.map((nodeTableName: string) => (this.columnTypes !== null ? Object.keys(this.columnTypes[nodeTableName]) : [])).flat();
 
       // Make the column names unique, no duplicates
       nodeColumnNames = [...new Set(nodeColumnNames)];
@@ -117,302 +103,144 @@ const {
       return nodeColumnNames;
     },
 
-    edgeVariableItems(state, getters): string[] {
-      if (getters.edgeTableName !== undefined && state.columnTypes !== null) {
-        return Object.keys(state.columnTypes[getters.edgeTableName]).filter((varName) => !isInternalField(varName));
+    edgeVariableItems(): string[] {
+      if (this.edgeTableName !== undefined && this.columnTypes !== null) {
+        return Object.keys(this.columnTypes[this.edgeTableName]).filter((varName) => !isInternalField(varName));
       }
       return [];
     },
 
-    nodeTableNames(state) {
-      return state.networkTables.filter((table) => !table.edge).map((table) => table.name);
+    nodeTableNames(): string[] {
+      return this.networkTables.filter((table) => !table.edge).map((table) => table.name);
     },
 
-    edgeTableName(state) {
-      const edgeTables = state.networkTables.filter((table) => table.edge);
+    edgeTableName(): string | undefined {
+      const edgeTable = this.networkTables.find((table) => table.edge);
 
-      return edgeTables.length > 0 ? edgeTables[0].name : undefined;
+      return edgeTable !== undefined ? edgeTable.name : undefined;
     },
   },
 
-  mutations: {
-    setWorkspaceName(state, workspaceName: string) {
-      state.workspaceName = workspaceName;
-    },
+  actions: {
+    async fetchNetwork(workspaceNameLocal: string, networkNameLocal: string) {
+      this.workspaceName = workspaceNameLocal;
+      this.networkName = networkNameLocal;
 
-    setNetworkName(state, networkName: string) {
-      state.networkName = networkName;
-    },
+      let network: NetworkSpec | undefined;
 
-    setNetwork(state, network: Network) {
-      if (!state.aggregated && !state.filteredNetwork) {
-        network.nodes = network.nodes.sort((node1, node2) => {
-          const key1 = parseInt(node1._key, 10);
-          const key2 = parseInt(node2._key, 10);
-
-          if (key1 && key2) {
-            return key1 - key2;
+      // Get all table names
+      try {
+        network = await api.network(this.workspaceName, this.networkName);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        if (error.status === 404) {
+          if (this.workspaceName === undefined || this.networkName === undefined) {
+            this.loadError = {
+              message: 'Workspace and/or network were not defined in the url',
+              href: 'https://multinet.app',
+            };
+          } else {
+            this.loadError = {
+              message: error.statusText,
+              href: 'https://multinet.app',
+            };
           }
-
-          return node1._key.localeCompare(node2._key);
-        });
+        } else if (error.status === 401) {
+          this.loadError = {
+            message: 'You are not authorized to view this workspace',
+            href: 'https://multinet.app',
+          };
+        } else {
+          this.loadError = {
+            message: 'An unexpected error ocurred',
+            href: 'https://multinet.app',
+          };
+        }
+      } finally {
+        if (this.loadError.message === '' && typeof network === 'undefined') {
+          // Catches CORS errors, issues when DB/API are down, etc.
+          this.loadError = {
+            message: 'There was a network issue when getting data',
+            href: `./?workspace=${this.workspaceName}&network=${this.networkName}`,
+          };
+        }
       }
-      state.network = network;
-    },
 
-    setLoadError(state, loadError: LoadError) {
-      state.loadError = {
-        message: loadError.message,
-        href: loadError.href,
-      };
-    },
-
-    setUserInfo(state, userInfo: UserSpec | null) {
-      state.userInfo = userInfo;
-    },
-
-    addSelectedNode(state, nodesToAdd: string[]) {
-      // If no nodes, do nothing
-      if (nodesToAdd.length === 0) {
+      if (network === undefined) {
         return;
       }
 
-      state.selectedNodes = new Set([...state.selectedNodes, ...nodesToAdd]);
-
-      if (state.provenance !== null) {
-        updateProvenanceState(state, 'Select Node(s)');
+      // Check network size
+      if (network.node_count > 300) {
+        this.loadError = {
+          message: 'The network you are loading is too large',
+          href: 'https://multinet.app',
+        };
       }
-    },
 
-    removeSelectedNode(state, nodeID: string) {
-      state.selectedNodes.delete(nodeID);
-      state.selectedNodes = new Set(state.selectedNodes);
-
-      if (state.provenance !== null) {
-        updateProvenanceState(state, 'De-select Node(s)');
-      }
-    },
-
-    clickCell(state, cellName: string) {
-      if (state.selectedCell !== null && state.selectedCell === cellName) {
-        state.selectedCell = null;
-        updateProvenanceState(state, 'De-Select Cell');
-      } else {
-        state.selectedCell = cellName;
-        updateProvenanceState(state, 'Select Cell');
-      }
-    },
-
-    setSortOrder(state, sortOrder: number[]) {
-      state.sortOrder = sortOrder;
-    },
-
-    pushHoveredNode(state, nodeID: string) {
-      if (state.hoveredNodes.indexOf(nodeID) === -1) {
-        state.hoveredNodes = [...state.hoveredNodes, nodeID];
-      }
-    },
-
-    removeHoveredNode(state, nodeID: string) {
-      state.hoveredNodes = state.hoveredNodes.filter((hoveredNode) => hoveredNode !== nodeID);
-    },
-
-    clearHoveredNodes(state) {
-      state.hoveredNodes = [];
-    },
-
-    setDirectionalEdges(state, directionalEdges: boolean) {
-      state.directionalEdges = directionalEdges;
-      const degreeObject = setNodeDegreeDict(store.state.networkPreFilter, store.state.networkOnLoad, store.state.connectivityMatrixPaths.paths.length > 0, store.state.directionalEdges);
-      state.maxDegree = degreeObject.maxDegree;
-      state.nodeDegreeDict = degreeObject.nodeDegreeDict;
-      if (state.provenance !== null) {
-        updateProvenanceState(state, 'Set Directional Edges');
-      }
-    },
-
-    setSelectNeighbors(state, selectNeighbors: boolean) {
-      state.selectNeighbors = selectNeighbors;
-
-      if (state.provenance !== null) {
-        updateProvenanceState(state, 'Set Select Neighbors');
-      }
-    },
-
-    setShowGridlines(state, showGridLines: boolean) {
-      state.showGridLines = showGridLines;
-
-      if (state.provenance !== null) {
-        updateProvenanceState(state, 'Set Show Grid Lines');
-      }
-    },
-
-    setAggregated(state, aggregated: boolean) {
-      state.aggregated = aggregated;
-      const degreeObject = setNodeDegreeDict(store.state.networkPreFilter, store.state.networkOnLoad, store.state.connectivityMatrixPaths.paths.length > 0, store.state.directionalEdges);
-      state.maxDegree = degreeObject.maxDegree;
-      state.nodeDegreeDict = degreeObject.nodeDegreeDict;
-    },
-
-    setAggregatedBy(state, varName: string | undefined) {
-      state.aggregatedBy = varName;
-    },
-
-    setQueriedNetworkState(state, queried: boolean) {
-      state.queriedNetwork = queried;
-    },
-
-    setMaxConnections(state, maxConnections: {
-      unAggr: number;
-      parent: number;
-    }) {
-      state.maxConnections = maxConnections;
-    },
-
-    setProvenance(state, provenance: Provenance<State, ProvenanceEventTypes, unknown>) {
-      state.provenance = provenance;
-    },
-
-    goToProvenanceNode(state, node: string) {
-      if (state.provenance !== null) {
-        state.provenance.goToNode(node);
-      }
-    },
-
-    toggleShowProvenanceVis(state) {
-      state.showProvenanceVis = !state.showProvenanceVis;
-    },
-
-    setAttributeValues(state, network: Network) {
-      const allNodeKeys: Set<string> = new Set();
-      network.nodes.forEach((node: Node) => Object.keys(node).forEach((key) => allNodeKeys.add(key)));
-      const nodeKeys = [...allNodeKeys];
-      state.nodeAttributes = nodeKeys.reduce((ac, a) => ({ ...ac, [a]: [] }), {});
-      nodeKeys.forEach((key: string) => {
-        state.nodeAttributes[key] = [...new Set(network.nodes.map((n: Node) => `${n[key]}`).sort())];
+      const networkTables = await api.networkTables(this.workspaceName, this.networkName);
+      this.networkTables = networkTables;
+      const metadataPromises: Promise<ColumnTypes>[] = [];
+      networkTables.forEach((table) => {
+        metadataPromises.push(api.columnTypes(this.workspaceName, table.name));
       });
 
-      const allEdgeKeys: Set<string> = new Set();
-      network.edges.forEach((edge: Edge) => Object.keys(edge).forEach((key) => allEdgeKeys.add(key)));
-      const edgeKeys = [...allEdgeKeys];
-      state.edgeAttributes = edgeKeys.reduce((ac, a) => ({ ...ac, [a]: [] }), {});
-      edgeKeys.forEach((key: string) => {
-        state.edgeAttributes[key] = [...new Set(network.edges.map((e: Edge) => `${e[key]}`).sort())];
+      // Resolve network metadata promises
+      const resolvedMetadataPromises = await Promise.all(metadataPromises);
+
+      // Combine all network metadata
+      let columnTypes: { [tableName: string]: ColumnTypes } = {};
+      resolvedMetadataPromises.forEach((types, i) => {
+        columnTypes = { ...columnTypes, [networkTables[i].name]: types };
       });
-    },
 
-    setLargeNetworkAttributeValues(state: State, payload: { nodeAttributes: ArangoAttributes; edgeAttributes: ArangoAttributes }) {
-      state.nodeAttributes = payload.nodeAttributes;
-      state.edgeAttributes = payload.edgeAttributes;
-    },
+      this.columnTypes = columnTypes;
 
-    toggleShowIntNodeVis(state, showIntNodeVis: boolean) {
-      state.showIntNodeVis = showIntNodeVis;
-    },
-
-    setConnectivityMatrixPaths(state, payload: { nodes: Node[]; paths: ArangoPath[]}) {
-      state.connectivityMatrixPaths = payload;
-    },
-
-    setSelectedConnectivityPaths(state, payload: number[]) {
-      state.selectedConnectivityPaths = payload.map((path: number) => state.connectivityMatrixPaths.paths[path]);
-    },
-
-    setSelectedHops(state, selectedHops: number) {
-      state.selectedHops = selectedHops;
-    },
-
-    setShowPathTable(state, showPathTable: boolean) {
-      state.showPathTable = showPathTable;
-    },
-
-    setCellSize(state, cellSize: number) {
-      state.cellSize = cellSize;
-    },
-
-    setMaxIntConnections(state, maxIntConnections) {
-      state.maxIntConnections = maxIntConnections;
-    },
-
-    setIntAggregatedBy(state, intAggregatedBy: string | undefined) {
-      state.intAggregatedBy = intAggregatedBy;
-    },
-
-    setNetworkTables(state, networkTables: Table[]) {
-      state.networkTables = networkTables;
-    },
-
-    setColumnTypes(state, columnTypes: { [tableName: string]: ColumnTypes }) {
-      state.columnTypes = columnTypes;
-    },
-
-    setLabelVariable(state, labelVariable: string | undefined) {
-      state.labelVariable = labelVariable;
-
-      if (state.provenance !== null) {
-        updateProvenanceState(state, 'Set Label Variable');
+      if (this.loadError.message !== '') {
+        return;
       }
+
+      // Generate all node table promises
+      const nodeRows = await api.nodes(this.workspaceName, this.networkName, { offset: 0, limit: 300 });
+
+      // Generate and resolve edge table promise and extract rows
+      const edges = await api.edges(this.workspaceName, this.networkName, { offset: 0, limit: 1000 });
+
+      const nodes = defineNeighbors(nodeRows.results, edges.results as Edge[]);
+
+      // Build the network object and set it as the network in the store
+      const networkElements = {
+        nodes: nodes as Node[],
+        edges: edges.results as Edge[],
+      };
+      this.setAttributeValues(networkElements);
+      this.networkOnLoad = networkElements;
+      this.updateNetwork(networkElements);
+      const degreeObject = setNodeDegreeDict(this.networkPreFilter, this.networkOnLoad, this.queriedNetwork, this.directionalEdges);
+      this.maxDegree = degreeObject.maxDegree;
+      this.nodeDegreeDict = degreeObject.nodeDegreeDict;
     },
 
-    updateRightClickMenu(state, payload: { show: boolean; top: number; left: number }) {
-      state.rightClickMenu = payload;
-    },
-
-    setIsDate(state, isDate: boolean) {
-      state.isDate = isDate;
-    },
-
-    setSlicedNetwork(state, slicedNetwork: SlicedNetwork[]) {
-      state.slicedNetwork = slicedNetwork;
-    },
-
-    setNetworkOnLoad(state, network: Network) {
-      state.networkOnLoad = structuredClone(network);
-    },
-
-    setSelected(state, selectedNodes: Set<string>) {
-      state.selectedNodes = selectedNodes;
-
-      if (state.provenance !== null) {
-        if (selectedNodes.size === 0) {
-          updateProvenanceState(state, 'Clear Selection');
-        }
-      }
-    },
-
-    setNetworkPreFilter(state, networkPostQuery: Network) {
-      state.networkPreFilter = networkPostQuery;
-    },
-
-    setFilteredNetwork(state, filteredNetwork: boolean) {
-      state.filteredNetwork = filteredNetwork;
-    },
-
-    setDegreeEntries(state, degreeObject: { maxDegree: number; nodeDegreeDict: {[key: string]: number}}) {
-      state.maxDegree = degreeObject.maxDegree;
-      state.nodeDegreeDict = degreeObject.nodeDegreeDict;
-    },
-
-    setDegreeNetwork(state, degreeRange: number[]) {
+    setDegreeNetwork(degreeRange: number[]) {
       // Determine correct network to use
       let baseNetwork: Network = { nodes: [], edges: [] };
-      if (state.networkPreFilter !== null || state.networkOnLoad !== null) {
-        baseNetwork = state.connectivityMatrixPaths.paths.length > 0 ? structuredClone(state.networkPreFilter as Network) : structuredClone(state.networkOnLoad as Network);
+      if (this.networkPreFilter !== null || this.networkOnLoad !== null) {
+        baseNetwork = this.connectivityMatrixPaths.paths.length > 0 ? structuredClone(this.networkPreFilter as Network) : structuredClone(this.networkOnLoad as Network);
       }
       // Restore network if min and max are restored
-      if (state.networkOnLoad !== null && degreeRange[0] === 0 && degreeRange[1] === state.maxDegree) {
-        store.commit.setFilteredNetwork(false);
-        store.dispatch.updateNetwork({ network: baseNetwork });
+      if (this.networkOnLoad !== null && degreeRange[0] === 0 && degreeRange[1] === this.maxDegree) {
+        this.filteredNetwork = false;
+        this.updateNetwork(baseNetwork);
       } else
       // Create new network to reflect degree filtering
-      if (state.networkOnLoad !== null) {
+      if (this.networkOnLoad !== null) {
         const nodeSet: Set<string> = new Set([]);
 
         // Remove edges that don't match degree criteria + store other edges in filtered edges
         const filteredEdges: Edge[] = [];
         baseNetwork.edges = baseNetwork.edges.filter((edge: Edge) => {
           // Create set of nodes that match criteria
-          if (state.nodeDegreeDict[edge._from] >= degreeRange[0] && state.nodeDegreeDict[edge._from] <= degreeRange[1] && state.nodeDegreeDict[edge._to] >= degreeRange[0] && state.nodeDegreeDict[edge._to] <= degreeRange[1]) {
+          if (this.nodeDegreeDict[edge._from] >= degreeRange[0] && this.nodeDegreeDict[edge._from] <= degreeRange[1] && this.nodeDegreeDict[edge._to] >= degreeRange[0] && this.nodeDegreeDict[edge._to] <= degreeRange[1]) {
             nodeSet.add(edge._from);
             nodeSet.add(edge._to);
             return true;
@@ -452,328 +280,217 @@ const {
             baseNetwork.edges.push(edge);
           }
         });
-        store.commit.setFilteredNetwork(true);
-        store.dispatch.updateNetwork({ network: baseNetwork });
+        this.filteredNetwork = true;
+        this.updateNetwork(baseNetwork);
       }
     },
 
-    setLineUpIsNested(state, lineupIsNested) {
-      state.lineupIsNested = lineupIsNested;
-    },
-  },
-
-  actions: {
-    async fetchNetwork(context, { workspaceName, networkName }) {
-      const { commit, dispatch } = rootActionContext(context);
-      commit.setWorkspaceName(workspaceName);
-      commit.setNetworkName(networkName);
-
-      let network: NetworkSpec | undefined;
-
-      // Get all table names
-      try {
-        network = await api.network(workspaceName, networkName);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
-        if (error.status === 404) {
-          if (workspaceName === undefined || networkName === undefined) {
-            commit.setLoadError({
-              message: 'Workspace and/or network were not defined in the url',
-              href: 'https://multinet.app',
-            });
-          } else {
-            commit.setLoadError({
-              message: error.statusText,
-              href: 'https://multinet.app',
-            });
-          }
-        } else if (error.status === 401) {
-          commit.setLoadError({
-            message: 'You are not authorized to view this workspace',
-            href: 'https://multinet.app',
-          });
-        } else {
-          commit.setLoadError({
-            message: 'An unexpected error ocurred',
-            href: 'https://multinet.app',
-          });
-        }
-      } finally {
-        if (store.state.loadError.message === '' && typeof network === 'undefined') {
-          // Catches CORS errors, issues when DB/API are down, etc.
-          commit.setLoadError({
-            message: 'There was a network issue when getting data',
-            href: `./?workspace=${workspaceName}&network=${networkName}`,
-          });
-        }
-      }
-
-      if (network === undefined) {
-        return;
-      }
-
-      // Check network size
-      if (network.node_count > 300) {
-        commit.setLoadError({
-          message: 'The network you are loading is too large',
-          href: 'https://multinet.app',
-        });
-      }
-
-      const networkTables = await api.networkTables(workspaceName, networkName);
-      commit.setNetworkTables(networkTables);
-      const metadataPromises: Promise<ColumnTypes>[] = [];
-      networkTables.forEach((table) => {
-        metadataPromises.push(api.columnTypes(workspaceName, table.name));
-      });
-
-      // Resolve network metadata promises
-      const resolvedMetadataPromises = await Promise.all(metadataPromises);
-
-      // Combine all network metadata
-      let columnTypes: { [tableName: string]: ColumnTypes } = {};
-      resolvedMetadataPromises.forEach((types, i) => {
-        columnTypes = { ...columnTypes, [networkTables[i].name]: types };
-      });
-
-      commit.setColumnTypes(columnTypes);
-
-      if (store.state.loadError.message !== '') {
-        return;
-      }
-
-      // Generate all node table promises
-      const nodeRows = await api.nodes(workspaceName, networkName, { offset: 0, limit: 300 });
-
-      // Generate and resolve edge table promise and extract rows
-      const edges = await api.edges(workspaceName, networkName, { offset: 0, limit: 1000 });
-
-      const nodes = defineNeighbors(nodeRows.results, edges.results as Edge[]);
-
-      // Build the network object and set it as the network in the store
-      const networkElements = {
-        nodes: nodes as Node[],
-        edges: edges.results as Edge[],
-      };
-      commit.setAttributeValues(networkElements);
-      commit.setNetworkOnLoad(networkElements);
-      dispatch.updateNetwork({ network: networkElements });
-      commit.setDegreeEntries(setNodeDegreeDict(store.state.networkPreFilter, store.state.networkOnLoad, store.state.queriedNetwork, store.state.directionalEdges));
+    updateNetwork(network: Network) {
+      this.network = network;
+      this.sortOrder = range(0, this.network.nodes.length);
+      this.slicedNetwork = [];
+      defineNeighbors(this.network.nodes, this.network.edges);
     },
 
-    updateNetwork(context, payload: { network: Network }) {
-      const { commit } = rootActionContext(context);
-      commit.setNetwork(payload.network);
-      commit.setSortOrder(range(0, payload.network.nodes.length));
-      commit.setSlicedNetwork([]);
-      defineNeighbors(payload.network.nodes, payload.network.edges);
-    },
-
-    async fetchUserInfo(context) {
-      const { commit } = rootActionContext(context);
-
+    async fetchUserInfo() {
       const info = await api.userInfo();
-      commit.setUserInfo(info);
+      this.userInfo = info;
     },
 
-    async logout(context) {
-      const { commit } = rootActionContext(context);
-
+    async logout() {
       // Perform the server logout.
       oauthClient.logout();
-      commit.setUserInfo(null);
+      this.userInfo = null;
     },
 
-    createProvenance(context) {
-      const { commit } = rootActionContext(context);
+    createProvenance() {
+      //   const storeState = this.$state;
 
-      const storeState = context.state;
+      //   const stateForProv = JSON.parse(JSON.stringify(this.$state));
+      //   stateForProv.selectedNodes = new Set<string>();
 
-      const stateForProv = JSON.parse(JSON.stringify(context.state));
-      stateForProv.selectedNodes = new Set<string>();
+      //   this.provenance = initProvenance<State, ProvenanceEventTypes, unknown>(
+      //     stateForProv,
+      //     { loadFromUrl: false },
+      //   );
 
-      commit.setProvenance(initProvenance<State, ProvenanceEventTypes, unknown>(
-        stateForProv,
-        { loadFromUrl: false },
-      ));
+      //   // Add a global observer to watch the state and update the tracked elements in the store
+      //   // enables undo/redo + navigating around provenance graph
+      //   storeState.provenance.addGlobalObserver(
+      //     () => {
+      //       const provenanceState = this.provenance.state;
 
-      // Add a global observer to watch the state and update the tracked elements in the store
-      // enables undo/redo + navigating around provenance graph
-      storeState.provenance.addGlobalObserver(
-        () => {
-          const provenanceState = context.state.provenance.state;
+      //       const { selectedNodes, selectedCell } = provenanceState;
 
-          const { selectedNodes, selectedCell } = provenanceState;
+      //       // Update selectedCell
+      //       storeState.selectedCell = selectedCell;
+      //       storeState.selectedNodes = selectedNodes;
 
-          // Update selectedCell
-          storeState.selectedCell = selectedCell;
-          storeState.selectedNodes = selectedNodes;
+      //       // Iterate through vars with primitive data types
+      //       [
+      //         'selectNeighbors',
+      //         'showGridLines',
+      //         'directionalEdges',
+      //         'enableAggregation',
+      //       ].forEach((primitiveVariable) => {
+      //         if (storeState[primitiveVariable] !== provenanceState[primitiveVariable]) {
+      //           storeState[primitiveVariable] = provenanceState[primitiveVariable];
+      //         }
+      //       });
+      //     },
+      //   );
 
-          // Iterate through vars with primitive data types
-          [
-            'selectNeighbors',
-            'showGridLines',
-            'directionalEdges',
-            'enableAggregation',
-          ].forEach((primitiveVariable) => {
-            if (storeState[primitiveVariable] !== provenanceState[primitiveVariable]) {
-              storeState[primitiveVariable] = provenanceState[primitiveVariable];
-            }
-          });
-        },
-      );
+      //   this.provenance.done();
 
-      storeState.provenance.done();
-
-      // Add keydown listener for undo/redo
-      document.addEventListener('keydown', (event) => undoRedoKeyHandler(event, storeState));
+      //   // Add keydown listener for undo/redo
+      //   document.addEventListener('keydown', (event) => undoRedoKeyHandler(event, storeState));
     },
 
-    aggregateNetwork(context, varName: string | undefined) {
-      const { state, commit, dispatch } = rootActionContext(context);
-
-      if (state.network !== null) {
-        store.commit.setAggregatedBy(varName);
-
-        // Reset network if aggregated
-        if (state.aggregated && varName === undefined) {
-          const unAggregatedNetwork = state.networkOnLoad !== null ? structuredClone(state.networkOnLoad) : { nodes: [], edges: [] };
-          store.commit.setAggregated(false);
-          store.commit.setNetworkPreFilter(unAggregatedNetwork);
-          dispatch.updateNetwork({ network: unAggregatedNetwork });
-        }
-
-        // Aggregate the network if the varName is not none
-        if (varName !== undefined) {
-          // Calculate edges
-          const newEdges: Edge[] = [];
-          state.network.edges.forEach((edge) => {
-            const fromNode = state.network && state.network.nodes.find((node) => node._id === edge._from);
-            const toNode = state.network && state.network.nodes.find((node) => node._id === edge._to);
-
-            // Add all super node to child node permutations
-            if (fromNode !== undefined && fromNode !== null) {
-              const newEdge = structuredClone(edge);
-              const fromNodeValue = fromNode[varName];
-              newEdge.originalFrom = newEdge.originalFrom === undefined ? newEdge._from : newEdge.originalFrom;
-              newEdge._from = `aggregated/${fromNodeValue}`;
-              newEdges.push(newEdge);
-            }
-
-            if (toNode !== undefined && toNode !== null) {
-              const newEdge = structuredClone(edge);
-              const toNodeValue = toNode[varName];
-              newEdge.originalTo = newEdge.originalTo === undefined ? newEdge._to : newEdge.originalTo;
-              newEdge._to = `aggregated/${toNodeValue}`;
-              newEdges.push(newEdge);
-            }
-
-            if (fromNode !== undefined && fromNode !== null && toNode !== undefined && toNode !== null) {
-              const newEdge = structuredClone(edge);
-              const fromNodeValue = fromNode[varName];
-              const toNodeValue = toNode[varName];
-              newEdge.originalFrom = newEdge.originalFrom === undefined ? newEdge._from : newEdge.originalFrom;
-              newEdge.originalTo = newEdge.originalTo === undefined ? newEdge._to : newEdge.originalTo;
-              newEdge._from = `aggregated/${fromNodeValue}`;
-              newEdge._to = `aggregated/${toNodeValue}`;
-              newEdges.push(newEdge);
-            }
-          });
-          const aggregatedEdges = [...state.network.edges, ...newEdges];
-
-          // Calculate nodes
-          const aggregatedNodes: Node[] = Array.from(
-            group(state.network.nodes, (d) => d[varName]),
-            ([key, value]) => ({
-              _id: `aggregated/${key}`,
-              _key: `${key}`,
-              _rev: '', // _rev property is needed to conform to Node interface
-              children: value.map((node) => structuredClone(node)),
-              type: 'supernode',
-              neighbors: [] as string[],
-              degreeCount: 0,
-              [varName]: key,
-            }),
-          );
-
-          // Set network and aggregated
-          commit.setAggregated(true);
-          store.commit.setNetworkPreFilter({ nodes: aggregatedNodes, edges: aggregatedEdges });
-          dispatch.updateNetwork({ network: { nodes: aggregatedNodes, edges: aggregatedEdges } });
-        }
+    goToProvenanceNode(node: string) {
+      if (this.provenance !== null) {
+        this.provenance.goToNode(node);
       }
     },
 
-    expandAggregatedNode(context, nodeID: string) {
-      const { state, dispatch } = rootActionContext(context);
+    setSelectedConnectivityPaths(payload: number[]) {
+      this.selectedConnectivityPaths = payload.map((path: number) => this.connectivityMatrixPaths.paths[path]);
+    },
 
-      if (state.network !== null) {
-        // Add children nodes into list at the correct index
-        const indexOfParent = state.network && state.network.nodes.findIndex((node) => node._id === nodeID);
-        let parentChildren = state.network.nodes[indexOfParent].children;
-        if (parentChildren === undefined) {
-          return;
-        }
+    aggregateNetwork(varName: string | undefined) {
+      this.aggregatedBy = varName;
 
-        parentChildren = parentChildren.map((child: Node) => {
-          child.parentPosition = indexOfParent;
-          return child;
-        }) || [];
-        const expandedNodes = [...state.network.nodes];
-        expandedNodes.splice(indexOfParent + 1, 0, ...parentChildren);
+      // Reset network if aggregated
+      if (this.aggregated && varName === undefined) {
+        const unAggregatedNetwork = this.networkOnLoad !== null ? structuredClone(this.networkOnLoad) : { nodes: [], edges: [] };
+        this.aggregated = false;
+        this.networkPreFilter = unAggregatedNetwork;
+        this.updateNetwork(unAggregatedNetwork);
+      }
 
-        dispatch.updateNetwork({ network: { nodes: expandedNodes, edges: state.network.edges } });
-        store.commit.setDegreeEntries(setNodeDegreeDict(store.state.networkPreFilter, store.state.networkOnLoad, store.state.queriedNetwork, store.state.directionalEdges));
+      // Aggregate the network if the varName is not none
+      if (varName !== undefined) {
+        // Calculate edges
+        const newEdges: Edge[] = [];
+        this.network.edges.forEach((edge) => {
+          const fromNode = this.network && this.network.nodes.find((node) => node._id === edge._from);
+          const toNode = this.network && this.network.nodes.find((node) => node._id === edge._to);
+
+          // Add all super node to child node permutations
+          if (fromNode !== undefined && fromNode !== null) {
+            const newEdge = structuredClone(edge);
+            const fromNodeValue = fromNode[varName];
+            newEdge.originalFrom = newEdge.originalFrom === undefined ? newEdge._from : newEdge.originalFrom;
+            newEdge._from = `aggregated/${fromNodeValue}`;
+            newEdges.push(newEdge);
+          }
+
+          if (toNode !== undefined && toNode !== null) {
+            const newEdge = structuredClone(edge);
+            const toNodeValue = toNode[varName];
+            newEdge.originalTo = newEdge.originalTo === undefined ? newEdge._to : newEdge.originalTo;
+            newEdge._to = `aggregated/${toNodeValue}`;
+            newEdges.push(newEdge);
+          }
+
+          if (fromNode !== undefined && fromNode !== null && toNode !== undefined && toNode !== null) {
+            const newEdge = structuredClone(edge);
+            const fromNodeValue = fromNode[varName];
+            const toNodeValue = toNode[varName];
+            newEdge.originalFrom = newEdge.originalFrom === undefined ? newEdge._from : newEdge.originalFrom;
+            newEdge.originalTo = newEdge.originalTo === undefined ? newEdge._to : newEdge.originalTo;
+            newEdge._from = `aggregated/${fromNodeValue}`;
+            newEdge._to = `aggregated/${toNodeValue}`;
+            newEdges.push(newEdge);
+          }
+        });
+        const aggregatedEdges = [...this.network.edges, ...newEdges];
+
+        // Calculate nodes
+        const aggregatedNodes: Node[] = Array.from(
+          group(this.network.nodes, (d) => d[varName]),
+          ([key, value]) => ({
+            _id: `aggregated/${key}`,
+            _key: `${key}`,
+            _rev: '', // _rev property is needed to conform to Node interface
+            children: value.map((node) => structuredClone(node)),
+            type: 'supernode',
+            neighbors: [] as string[],
+            degreeCount: 0,
+            [varName]: key,
+          }),
+        );
+
+        // Set network and aggregated
+        this.aggregated = true;
+        this.networkPreFilter = { nodes: aggregatedNodes, edges: aggregatedEdges };
+        this.updateNetwork({ nodes: aggregatedNodes, edges: aggregatedEdges });
       }
     },
 
-    retractAggregatedNode(context, nodeID: string) {
-      const { state, dispatch } = rootActionContext(context);
-
-      if (state.network !== null) {
-        // Remove children nodes
-        const parentNode = state.network.nodes.find((node) => node._id === nodeID);
-        const parentChildren = parentNode && parentNode.children;
-        const retractedNodes = state.network.nodes.filter((node) => parentChildren && parentChildren.indexOf(node) === -1);
-
-        dispatch.updateNetwork({ network: { nodes: retractedNodes, edges: state.network.edges } });
-        store.commit.setDegreeEntries(setNodeDegreeDict(store.state.networkPreFilter, store.state.networkOnLoad, store.state.queriedNetwork, store.state.directionalEdges));
+    expandAggregatedNode(nodeID: string) {
+      // Add children nodes into list at the correct index
+      const indexOfParent = this.network && this.network.nodes.findIndex((node) => node._id === nodeID);
+      let parentChildren = this.network.nodes[indexOfParent].children;
+      if (parentChildren === undefined) {
+        return;
       }
+
+      parentChildren = parentChildren.map((child: Node) => {
+        child.parentPosition = indexOfParent;
+        return child;
+      }) || [];
+      const expandedNodes = [...this.network.nodes];
+      expandedNodes.splice(indexOfParent + 1, 0, ...parentChildren);
+
+      this.updateNetwork({ nodes: expandedNodes, edges: this.network.edges });
+      const degreeObject = setNodeDegreeDict(this.networkPreFilter, this.networkOnLoad, this.queriedNetwork, this.directionalEdges);
+      this.maxDegree = degreeObject.maxDegree;
+      this.nodeDegreeDict = degreeObject.nodeDegreeDict;
     },
 
-    clickElement(context, elementID: string) {
-      const { state, commit } = rootActionContext(context);
-      if (!state.selectedNodes.has(elementID)) {
-        commit.addSelectedNode([elementID]);
+    retractAggregatedNode(nodeID: string) {
+      // Remove children nodes
+      const parentNode = this.network.nodes.find((node) => node._id === nodeID);
+      const parentChildren = parentNode && parentNode.children;
+      const retractedNodes = this.network.nodes.filter((node) => parentChildren && parentChildren.indexOf(node) === -1);
+
+      this.updateNetwork({ nodes: retractedNodes, edges: this.network.edges });
+      const degreeObject = setNodeDegreeDict(this.networkPreFilter, this.networkOnLoad, this.queriedNetwork, this.directionalEdges);
+      this.maxDegree = degreeObject.maxDegree;
+      this.nodeDegreeDict = degreeObject.nodeDegreeDict;
+    },
+
+    clickElement(elementID: string) {
+      if (!this.selectedNodes.includes(elementID)) {
+        this.selectedNodes.push(elementID);
       } else {
-        commit.removeSelectedNode(elementID);
+        this.selectedNodes = this.selectedNodes.filter((nodeID) => nodeID !== elementID);
       }
     },
 
-    clearSelection(context) {
-      const { state, commit } = rootActionContext(context);
-
-      commit.setSelected(new Set());
-      if (state.selectedCell !== null) {
-        commit.clickCell(state.selectedCell);
+    clearSelection() {
+      this.selectedNodes = [];
+      if (this.selectedCell !== null) {
+        this.selectedCell = null;
       }
+    },
+
+    setAttributeValues(network: Network) {
+      const allNodeKeys: Set<string> = new Set();
+      network.nodes.forEach((node: Node) => Object.keys(node).forEach((key) => allNodeKeys.add(key)));
+      const nodeKeys = [...allNodeKeys];
+      this.nodeAttributes = nodeKeys.reduce((ac, a) => ({ ...ac, [a]: [] }), {});
+      nodeKeys.forEach((key: string) => {
+        this.nodeAttributes[key] = [...new Set(network.nodes.map((n: Node) => `${n[key]}`).sort())];
+      });
+
+      const allEdgeKeys: Set<string> = new Set();
+      network.edges.forEach((edge: Edge) => Object.keys(edge).forEach((key) => allEdgeKeys.add(key)));
+      const edgeKeys = [...allEdgeKeys];
+      this.edgeAttributes = edgeKeys.reduce((ac, a) => ({ ...ac, [a]: [] }), {});
+      edgeKeys.forEach((key: string) => {
+        this.edgeAttributes[key] = [...new Set(network.edges.map((e: Edge) => `${e[key]}`).sort())];
+      });
     },
   },
 });
-
-export default store;
-export {
-  rootActionContext,
-  moduleActionContext,
-  rootGetterContext,
-  moduleGetterContext,
-};
-
-// The following lines enable types in the injected store '$store'.
-export type ApplicationStore = typeof store;
-declare module 'vuex' {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface Store<S> {
-    direct: ApplicationStore;
-  }
-}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -35,7 +35,7 @@ export const useStore = defineStore('store', {
     selectNeighbors: true,
     showGridLines: true,
     aggregated: false,
-    aggregatedBy: undefined,
+    aggregatedBy: null,
     maxConnections: {
       unAggr: 0,
       parent: 0,
@@ -356,11 +356,11 @@ export const useStore = defineStore('store', {
       this.selectedConnectivityPaths = payload.map((path: number) => this.connectivityMatrixPaths.paths[path]);
     },
 
-    aggregateNetwork(varName: string | undefined) {
+    aggregateNetwork(varName: string | null) {
       this.aggregatedBy = varName;
 
       // Reset network if aggregated
-      if (this.aggregated && varName === undefined) {
+      if (this.aggregated && varName === null) {
         const unAggregatedNetwork = this.networkOnLoad !== null ? structuredClone(this.networkOnLoad) : { nodes: [], edges: [] };
         this.aggregated = false;
         this.networkPreFilter = unAggregatedNetwork;
@@ -368,7 +368,7 @@ export const useStore = defineStore('store', {
       }
 
       // Aggregate the network if the varName is not none
-      if (varName !== undefined) {
+      if (varName !== null) {
         // Calculate edges
         const newEdges: Edge[] = [];
         this.network.edges.forEach((edge) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,7 +102,7 @@ export interface State {
   selectNeighbors: boolean;
   showGridLines: boolean;
   aggregated: boolean;
-  aggregatedBy: string | undefined;
+  aggregatedBy: string | null;
   maxConnections: {
     unAggr: number;
     parent: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,15 +86,15 @@ export type ProvenanceEventTypes =
   'Set Label Variable';
 
 export interface State {
-  workspaceName: string | null;
-  networkName: string | null;
+  workspaceName: string;
+  networkName: string;
   networkOnLoad: Network | null;
   slicedNetwork: SlicedNetwork[];
-  network: Network | null;
+  network: Network;
   loadError: LoadError;
   userInfo: UserSpec | null;
   cellSize: number;
-  selectedNodes: Set<string>;
+  selectedNodes: string[];
   selectedCell: string | null;
   hoveredNodes: string[];
   sortOrder: number[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3113,6 +3113,11 @@
     postcss "^8.4.14"
     source-map "^0.6.1"
 
+"@vue/devtools-api@^6.4.5":
+  version "6.4.5"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.4.5.tgz#d54e844c1adbb1e677c81c665ecef1a2b4bb8380"
+  integrity sha512-JD5fcdIuFxU4fQyXUu3w2KpAJHzTVdN+p4iOX2lMWSHMOoQdMAcpFLZzm9Z/2nmsoZ1a96QEhZ26e50xLBsgOQ==
+
 "@vue/eslint-config-airbnb@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@vue/eslint-config-airbnb/-/eslint-config-airbnb-7.0.0.tgz#eb61c44f96ce17b57dd866a4086bdf757c869e40"
@@ -5529,11 +5534,6 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
-
-direct-vuex@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/direct-vuex/-/direct-vuex-0.12.0.tgz#aba06acc5def3c5cd8e26b6dabb0557e9d074ddf"
-  integrity sha512-yhIlQl9nfKtP55ZEomljcEsxq9rWWc6Fo/DhuU2SIN24qIa4VfTY1dcCAAOQrYdZt4+id5hHjWMdDFa0BDGgSw==
 
 django-s3-file-field@^0.1.2:
   version "0.1.2"
@@ -9661,6 +9661,14 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+pinia@^2.0.28:
+  version "2.0.28"
+  resolved "https://registry.yarnpkg.com/pinia/-/pinia-2.0.28.tgz#887c982d854972042d9bdfd5bc4fad3b9d6ab02a"
+  integrity sha512-YClq9DkqCblq9rlyUual7ezMu/iICWdBtfJrDt4oWU9Zxpijyz7xB2xTwx57DaBQ96UGvvTMORzALr+iO5PVMw==
+  dependencies:
+    "@vue/devtools-api" "^6.4.5"
+    vue-demi "*"
+
 pirates@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
@@ -12157,6 +12165,11 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
+vue-demi@*:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.13.11.tgz#7d90369bdae8974d87b1973564ad390182410d99"
+  integrity sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==
+
 vue-eslint-parser@^7.10.0:
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-7.11.0.tgz#214b5dea961007fcffb2ee65b8912307628d0daf"
@@ -12216,11 +12229,6 @@ vuetify@^2.6.10:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.6.10.tgz#b86cd7a97bf8cd3828a72c349795b5b3c539ebc2"
   integrity sha512-fgUeRDDCwYkwu6WGEEKGe7IdfzOsXJCZGrqkn1pcS2ycuoDL8mR2/dejH5iFNnBY6MnsT365PAGn0J+9otjfQg==
-
-vuex@^3.6.0:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.6.2.tgz#236bc086a870c3ae79946f107f16de59d5895e71"
-  integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #

### Give a longer description of what this PR addresses and why it's needed
This vastly simplifies the store object that we have to maintain. We've gone from requiring mutations, to not, and we now have a path forward on the vue 3 sanctioned store library. While this change wasn't strictly necessary for that change, we're now not using direct-vuex, and we no longer need to use computed get/set logic to update. That is a huge simplification.

The only remaining changes to get us fully up to date with vue 3 will be migrating to it, and using vuetify 3. Vuetify is still in beta, and not well documented at the moment. I think it would be prescient to wait a little while longer for that migration.

I removed some javascript Set logic here, since vue 2 doesn't deal with the reactivity of Sets. We can plan to add that back when we're using vue 3, since they are supported there.

### Provide pictures/videos of the behavior before and after these changes (optional)
No change

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Update relevant documentation