### PR TITLE
Drop d3-svg-legend, add custom component ColorScaleLegend

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@types/node": "^17.0.29",
     "@vitejs/plugin-vue2": "^2.2.0",
     "d3": "7.8.0",
-    "d3-svg-legend": "^2.25.6",
     "eslint-import-resolver-alias": "^1.1.2",
     "lineupjs": "^4.2.0",
     "multinet": "^0.21.11",

--- a/src/components/ColorScaleLegend.vue
+++ b/src/components/ColorScaleLegend.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-row class="pb-0 px-0">
+    <v-col style="width: 75px; max-width: 75px;">
+      {{ props.label }}
+    </v-col>
+    <v-col style="width: 150px; max-width: 150px;">
+      <svg height="50" width="150">
+        <rect
+          v-for="item, index in items"
+          :key="`rect_${index}`"
+          :fill="item.input === 0 ? '#FFFFFF' : `${item.value}`"
+          :x="(index * (rectWidth + rectPad)) + 1"
+          y="10"
+          height="15"
+          :width="rectWidth"
+          style="stroke-width: 1px; stroke:rgb(0,0,0);"
+        />
+        <text
+          v-for="item, index in items"
+          :key="`text_${index}`"
+          :x="(index * (rectWidth + rectPad)) + (rectWidth / 2)"
+          y="40"
+          text-anchor="middle"
+        >
+          {{ item.input }}
+        </text>
+      </svg>
+    </v-col>
+  </v-row>
+</template>
+
+<script setup lang="ts">
+import { ScaleLinear } from 'd3';
+import { computed } from 'vue';
+
+const props = defineProps<{ scale: ScaleLinear<string, number>; label: string }>();
+
+const rectWidth = 25;
+const rectPad = 5;
+
+const items = computed(() => {
+  const domain = props.scale.domain();
+  let valuesInDomain = Array(domain[1] - domain[0] + 1).fill(0).map((x, i) => ({ input: i, value: props.scale(i) }));
+
+  // If we have more than 5 values, let's only select the quartile values
+  if (valuesInDomain.length > 5) {
+    const idxToSelect = [
+      0,
+      Math.floor(valuesInDomain.length * 0.25),
+      Math.floor(valuesInDomain.length * 0.5),
+      Math.floor(valuesInDomain.length * 0.75),
+      valuesInDomain.length - 1,
+    ];
+
+    valuesInDomain = valuesInDomain.filter((x, i) => idxToSelect.includes(i));
+  }
+
+  return valuesInDomain;
+});
+</script>
+
+<style>
+svg {
+  min-width: 150px;
+}
+</style>

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -275,7 +275,7 @@ function removeByDegree() {
           </v-list-item>
 
           <!-- Matrix Legend -->
-          <color-scale-legend v-if="maxIntConnections > 0" :scale="intTableColorScale" label="Legend" />
+          <color-scale-legend v-if="maxIntConnections > 0" :scale="intTableColorScale" label="Count of Edges" />
         </div>
       </div>
       <!-- Edge Slicing -->

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { select, format, ScaleLinear } from 'd3';
-import { legendColor } from 'd3-svg-legend';
 import { Node, Edge, ArangoPath } from '@/types';
 import { useStore } from '@/store';
 import ConnectivityQuery from '@/components/ConnectivityQuery.vue';
@@ -9,6 +7,7 @@ import {
   computed, ref, watch, watchEffect,
 } from 'vue';
 import { storeToRefs } from 'pinia';
+import ColorScaleLegend from '@/components/ColorScaleLegend.vue';
 
 const store = useStore();
 const {
@@ -48,28 +47,6 @@ const aggregationItems = computed(() => {
   return Object.values(nodeColumnTypes).map((colTypes) => Object.entries(colTypes).filter(([_, colType]) => colType === 'category').map(([varName, _]) => varName)).flat();
 });
 
-function updateLegend(colorScale: ScaleLinear<string, number>, legendName: 'parent' | 'unAggr' | 'intTable') {
-  let legendSVG;
-  if (legendName === 'parent') {
-    legendSVG = select('#parent-matrix-legend');
-  } else if (legendName === 'unAggr') {
-    legendSVG = select('#matrix-legend');
-  } else {
-    legendSVG = select('#int-matrix-legend');
-  }
-
-  // construct the legend and format the labels to have 0 decimal places
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const legendLinear = (legendColor() as any)
-    .shapeWidth(20)
-    .cells(colorScale.domain()[1] >= 5 ? 5 : colorScale.domain()[1] + 1)
-    .orient('horizontal')
-    .scale(colorScale)
-    .labelFormat(format('.0f'));
-
-  legendSVG.select('.legendLinear').call(legendLinear);
-}
-
 function displayCSVBuilder() {
   const reconstructedPaths: ArangoPath[] = [];
 
@@ -96,9 +73,6 @@ function displayCSVBuilder() {
   showPathTable.value = true;
 }
 
-watchEffect(() => updateLegend(cellColorScale.value, 'unAggr'));
-watchEffect(() => updateLegend(parentColorScale.value, 'parent'));
-watchEffect(() => updateLegend(intTableColorScale.value, 'intTable'));
 watchEffect(() => {
   if (!showIntNodeVis.value) {
     intAggregatedBy.value = undefined;
@@ -266,44 +240,15 @@ function removeByDegree() {
       </v-card>
 
       <v-subheader class="grey darken-3 py-0 white--text">
-        Color Scale Legend
+        Edge Legend
       </v-subheader>
 
       <div class="pa-4">
         <!-- Aggregated Matrix Legend -->
-        <v-list-item
-          v-if="aggregated || degreeFiltered"
-          class="pb-0 px-0"
-          style="display: flex; max-height: 50px"
-        >
-          {{ aggregated ? 'Aggregate Legend' : 'Filtered Legend' }}
-          <svg
-            id="parent-matrix-legend"
-            height="50"
-          >
-            <g
-              class="legendLinear"
-              transform="translate(10, 10)"
-            />
-          </svg>
-        </v-list-item>
+        <color-scale-legend v-if="aggregated || degreeFiltered" :scale="parentColorScale" :label="aggregated ? 'Count of Aggregated Edges' : 'Count of Filtered Edges'" />
 
         <!-- Matrix Legend -->
-        <v-list-item
-          class="pb-0 px-0"
-          :style="`display: flex; max-height: 50px; opacity: ${maxConnections.unAggr > 0 ? 1 : 0}`"
-        >
-          {{ aggregated ? 'Child Legend' : 'Matrix Legend' }}
-          <svg
-            id="matrix-legend"
-            height="50"
-          >
-            <g
-              class="legendLinear"
-              transform="translate(10, 10)"
-            />
-          </svg>
-        </v-list-item>
+        <color-scale-legend v-if="maxConnections.unAggr > 0" :scale="cellColorScale" :label="aggregated ? 'Count of Child Edges' : 'Count of Edges'" />
       </div>
 
       <!-- Int Table Controls + Legend -->
@@ -330,21 +275,7 @@ function removeByDegree() {
           </v-list-item>
 
           <!-- Matrix Legend -->
-          <v-list-item
-            class="pb-0 px-0"
-            :style="`display: flex; max-height: 50px; opacity: ${maxIntConnections > 0 ? 1 : 0}`"
-          >
-            {{ 'Legend' }}
-            <svg
-              id="int-matrix-legend"
-              height="50"
-            >
-              <g
-                class="legendLinear"
-                transform="translate(10, 10)"
-              />
-            </svg>
-          </v-list-item>
+          <color-scale-legend v-if="maxIntConnections > 0" :scale="intTableColorScale" label="Legend" />
         </div>
       </div>
       <!-- Edge Slicing -->

--- a/yarn.lock
+++ b/yarn.lock
@@ -724,11 +724,6 @@
   resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-1.4.1.tgz#fa1f8710a6b5d7cfe5c6caa61d161be7cae4a022"
   integrity sha512-bv8IfFYo/xG6dxri9OwDnK3yCagYPeRIjTlrcdYJSx+FDWlCeBDepIHUpqROmhPtZ53jyna0aUajZRk0I3rXNA==
 
-"@types/d3-selection@1.0.10":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-1.0.10.tgz#dcfb0ddfcdfb1ad26aea4351323771e1aea96e84"
-  integrity sha512-mHICSFHpIwgTycsvgINYCwItk039eofbGRzVNdeUUtv0S2BD1vXFFUKaeMJN3ARbVl+hlsVOIwdzhzub5tjr6Q==
-
 "@types/d3-shape@*":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-1.3.2.tgz#a41d9d6b10d02e221696b240caf0b5d0f5a588ec"
@@ -1505,16 +1500,6 @@ csstype@^3.1.0:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
   integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
 
-d3-array@1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
-  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
-
-d3-array@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.0.1.tgz#375c02874fcd96c16ed9f1bcf5b4a7be53f358e7"
-  integrity sha512-VPS5OH5Xb43tkFkxHEc4r5yWhlDwST47zh1q+qvgTj7xB9xDXn+UEcofhvNC7s8gD55y9Q/MCSPSBUVvnzo3Dw==
-
 d3-array@2:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.12.1.tgz#e20b41aafcdffdf5d50928004ececf815a465e81"
@@ -1557,16 +1542,6 @@ d3-chord@3:
   dependencies:
     d3-path "1 - 3"
 
-d3-collection@1:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
-  integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
-
-d3-color@1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
-  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
-
 "d3-color@1 - 2", d3-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
@@ -1591,20 +1566,10 @@ d3-delaunay@6:
   dependencies:
     delaunator "5"
 
-d3-dispatch@1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
-  integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
-
 "d3-dispatch@1 - 3", d3-dispatch@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
   integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
-
-d3-dispatch@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.1.tgz#4bd65a43cecff4318deb9df24552aa8bf281a840"
-  integrity sha512-BRTp95mobTSKx8EtpOLbxXuYVtNNr0PmelkH9Uzg5cgcO5O1M0i3+2C0FeM2I95BwQoIlsuZXQTPIoIt5xOtmw==
 
 d3-dispatch@^2.0.0:
   version "2.0.0"
@@ -1628,11 +1593,6 @@ d3-dispatch@^2.0.0:
     iconv-lite "0.6"
     rw "1"
 
-d3-ease@1:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.7.tgz#9a834890ef8b8ae8c558b2fe55bd57f5993b85e2"
-  integrity sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==
-
 "d3-ease@1 - 3", d3-ease@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
@@ -1654,11 +1614,6 @@ d3-force@3:
     d3-quadtree "1 - 3"
     d3-timer "1 - 3"
 
-d3-format@1:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.5.tgz#374f2ba1320e3717eb74a9356c67daee17a7edb4"
-  integrity sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==
-
 "d3-format@1 - 2", d3-format@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-2.0.0.tgz#a10bcc0f986c372b729ba447382413aabf5b0767"
@@ -1668,11 +1623,6 @@ d3-format@1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
   integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
-
-d3-format@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.0.2.tgz#138618320b4bbeb43b5c0ff30519079fbbd7375e"
-  integrity sha512-VHFdLLjGkeGrRL8T/rlIIDhI3vvVX/oOTM/GaDJfB1sIb4dU5ZgiEjg3EeidJdQ/70u60tM015TSWa1gqqLRhg==
 
 d3-geo@3:
   version "3.1.0"
@@ -1685,13 +1635,6 @@ d3-hierarchy@3:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
   integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
-
-d3-interpolate@1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
-  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
-  dependencies:
-    d3-color "1"
 
 "d3-interpolate@1 - 2", "d3-interpolate@1.2.0 - 2":
   version "2.0.1"
@@ -1743,19 +1686,6 @@ d3-scale-chromatic@^2.0.0:
     d3-color "1 - 2"
     d3-interpolate "1 - 2"
 
-d3-scale@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.3.tgz#4f9e8f0cc2ea0f3925ff04ac27adc09045fa4c90"
-  integrity sha512-ah2Xqywu96gau2iET3T0ZTsu0/X0gfoB8vDTuZ1OaG5F0SgGJLXreBVBknSZf2HKnxjenRvFok3qY2FgY4RpFg==
-  dependencies:
-    d3-array "1"
-    d3-collection "1"
-    d3-color "1"
-    d3-format "1"
-    d3-interpolate "1"
-    d3-time "1"
-    d3-time-format "2"
-
 d3-scale@4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
@@ -1778,16 +1708,6 @@ d3-scale@^3.2.3:
     d3-time "1 - 2"
     d3-time-format "2 - 3"
 
-d3-selection@1:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.2.tgz#dcaa49522c0dbf32d6c1858afc26b6094555bc5c"
-  integrity sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==
-
-d3-selection@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.0.2.tgz#ae662afd4702ac9c5da039b2107a1764fa1c9070"
-  integrity sha512-nInNdsdhljkDqkU/83bdWwtiJ7xsX3l57YZMlqsAOMeQROeCv7osPqQgYnao0NmRZEGc11hNakY+EOkaIdsWpQ==
-
 "d3-selection@2 - 3", d3-selection@3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
@@ -1799,26 +1719,6 @@ d3-shape@3:
   integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
   dependencies:
     d3-path "^3.1.0"
-
-d3-svg-legend@^2.25.6:
-  version "2.25.6"
-  resolved "https://registry.yarnpkg.com/d3-svg-legend/-/d3-svg-legend-2.25.6.tgz#8d8dc1bd693c378ee48b6f823e8a24e68f2e1ad2"
-  integrity sha512-6dueSjQr3+g9SlQ1SOzc4V58cCjjBeyo4WEcY8PW80i9XD/s562W/4xk05bpky0vzQx+i2XmXj3CYT+9KIRlnw==
-  dependencies:
-    "@types/d3-selection" "1.0.10"
-    d3-array "1.0.1"
-    d3-dispatch "1.0.1"
-    d3-format "1.0.2"
-    d3-scale "1.0.3"
-    d3-selection "1.0.2"
-    d3-transition "1.0.3"
-
-d3-time-format@2:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.3.0.tgz#107bdc028667788a8924ba040faf1fbccd5a7850"
-  integrity sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==
-  dependencies:
-    d3-time "1"
 
 "d3-time-format@2 - 3", d3-time-format@^3.0.0:
   version "3.0.0"
@@ -1833,11 +1733,6 @@ d3-time-format@2:
   integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
   dependencies:
     d3-time "1 - 3"
-
-d3-time@1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
-  integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
 
 "d3-time@1 - 2":
   version "2.0.0"
@@ -1858,27 +1753,10 @@ d3-time@^2.0.0:
   dependencies:
     d3-array "2"
 
-d3-timer@1:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
-  integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
-
 "d3-timer@1 - 3", d3-timer@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
   integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
-
-d3-transition@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.0.3.tgz#91dc986bddb30973639320a85db72ce4ab1a27bb"
-  integrity sha512-Facxcbma0nA2GVrx7B/Mgnn5ju6SwUMzGa9YcYmQjpqmaIq1Zbp5vVJLjtH6b08Lu0vcX7O6a4z+AlLmdCxrCQ==
-  dependencies:
-    d3-color "1"
-    d3-dispatch "1"
-    d3-ease "1"
-    d3-interpolate "1"
-    d3-selection "1"
-    d3-timer "1"
 
 "d3-transition@2 - 3", d3-transition@3:
   version "3.0.1"


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #441 

### Give a longer description of what this PR addresses and why it's needed
This refactor the color scale legend code to use a custom component, instead of relying on the defunct and unmaintained d3-svg-legend library.

### Provide pictures/videos of the behavior before and after these changes (optional)
Edge Legend:
<img width="255" alt="Screenshot 2023-03-30 at 12 28 01 PM" src="https://user-images.githubusercontent.com/36867477/228930459-aa3f50a0-0629-4f1b-ae78-2df8e6000155.png">

Int Node Table:
<img width="255" alt="Screenshot 2023-03-30 at 12 30 37 PM" src="https://user-images.githubusercontent.com/36867477/228931011-92341c0a-8e73-4b55-bcce-dd8ef5b3ace8.png">

### Are there any additional TODOs before this PR is ready to go?
No