### PR TITLE
Fix matrix sorting and add it to trrack provenance

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -27,10 +27,10 @@ const { rightClickMenu, sortBy } = storeToRefs(store);
         <v-list-item
           v-if="rightClickMenu.nodeID !== undefined"
           dense
-          @click="sortBy = rightClickMenu.nodeID"
+          @click="sortBy.node = sortBy.node === rightClickMenu.nodeID ? null : rightClickMenu.nodeID"
         >
           <v-list-item-content>
-            <v-list-item-title>Sort Neighbors</v-list-item-title>
+            <v-list-item-title>{{ sortBy.node === rightClickMenu.nodeID ? 'Remove Neighbor Sort' : 'Sort Neighbors' }}</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
       </v-list>

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -3,11 +3,7 @@ import { useStore } from '@/store';
 import { storeToRefs } from 'pinia';
 
 const store = useStore();
-const { rightClickMenu } = storeToRefs(store);
-
-function clearSelection() {
-  store.clearSelection();
-}
+const { rightClickMenu, sortBy } = storeToRefs(store);
 </script>
 
 <template>
@@ -22,10 +18,19 @@ function clearSelection() {
       <v-list>
         <v-list-item
           dense
-          @click="clearSelection"
+          @click="store.clearSelection()"
         >
           <v-list-item-content>
             <v-list-item-title>Clear Selection</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item
+          v-if="rightClickMenu.nodeID !== undefined"
+          dense
+          @click="sortBy = rightClickMenu.nodeID"
+        >
+          <v-list-item-content>
+            <v-list-item-title>Sort Neighbors</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
       </v-list>

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -34,6 +34,7 @@ const {
   network,
   connectivityMatrixPaths,
   degreeRange,
+  sortBy,
 } = storeToRefs(store);
 
 // Template objects
@@ -84,6 +85,8 @@ watch(degreeRange, () => { degreeRangeLocal.value = degreeRange.value; });
 function removeByDegree() {
   degreeRange.value = degreeRangeLocal.value;
 }
+
+const sortByItems = ['Alphabetically', 'Clusters', 'Interactions'];
 </script>
 
 <template>
@@ -142,6 +145,18 @@ function removeByDegree() {
             outlined
             dense
             @change="store.aggregateNetwork"
+          />
+        </v-list-item>
+        <v-list-item>
+          <v-autocomplete
+            v-model="sortBy"
+            label="Sort By"
+            :items="sortByItems"
+            :hide-details="true"
+            class="mt-3"
+            clearable
+            outlined
+            dense
           />
         </v-list-item>
 

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -86,7 +86,7 @@ function removeByDegree() {
   degreeRange.value = degreeRangeLocal.value;
 }
 
-const sortByItems = ['Alphabetically', 'Clusters', 'Interactions'];
+const sortByItems = ['Alphabetically', 'Clusters', 'RCM'];
 </script>
 
 <template>
@@ -149,7 +149,7 @@ const sortByItems = ['Alphabetically', 'Clusters', 'Interactions'];
         </v-list-item>
         <v-list-item>
           <v-autocomplete
-            v-model="sortBy"
+            v-model="sortBy.network"
             label="Sort By"
             :items="sortByItems"
             :hide-details="true"
@@ -157,6 +157,7 @@ const sortByItems = ['Alphabetically', 'Clusters', 'Interactions'];
             clearable
             outlined
             dense
+            @change="sortBy.node = null"
           />
         </v-list-item>
 

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -61,12 +61,12 @@ const lineupOrder = computed(() => {
 });
 
 // If store order has changed, update lineup
-let permutingMatrix = structuredClone(sortOrder.value);
+let permutingMatrix = structuredClone(sortOrder.value.row);
 watch(sortOrder, (newSortOrder) => {
   if (lineup.value !== null) {
-    permutingMatrix = structuredClone(newSortOrder);
+    permutingMatrix = structuredClone(newSortOrder.row);
     lineup.value.data.getFirstRanking().setSortCriteria([]);
-    const sortedData = newSortOrder.map((i) => (network.value !== null ? network.value.nodes[i] : {}));
+    const sortedData = newSortOrder.row.map((i) => (network.value !== null ? network.value.nodes[i] : {}));
     (lineup.value.data as LocalDataProvider).setData(sortedData);
   }
 });
@@ -75,7 +75,7 @@ watch(sortOrder, (newSortOrder) => {
 watch(lineupOrder, () => {
   if (lineup.value !== null && network.value !== null) {
     lineup.value.data.getFirstRanking().setSortCriteria([]);
-    const sortedData = sortOrder.value.map((i) => (network.value !== null ? network.value.nodes[i] : {}));
+    const sortedData = sortOrder.value.row.map((i) => (network.value !== null ? network.value.nodes[i] : {}));
     (lineup.value.data as LocalDataProvider).setData(sortedData);
   }
 });

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -53,7 +53,6 @@ const lineupHeight = computed(() => {
   return possibleHeight < 500 ? 500 : possibleHeight;
 });
 
-let lineupIsSorter = false;
 const lineupOrder = computed(() => {
   if (lineup.value === null || [...lineup.value.data.getFirstRanking().getOrder()].length === 0) {
     return [...Array(network.value?.nodes.length).keys()];
@@ -64,26 +63,20 @@ const lineupOrder = computed(() => {
 // If store order has changed, update lineup
 let permutingMatrix = structuredClone(sortOrder.value);
 watch(sortOrder, (newSortOrder) => {
-  if (lineup.value !== null && !lineupIsSorter) {
+  if (lineup.value !== null) {
     permutingMatrix = structuredClone(newSortOrder);
     lineup.value.data.getFirstRanking().setSortCriteria([]);
     const sortedData = newSortOrder.map((i) => (network.value !== null ? network.value.nodes[i] : {}));
     (lineup.value.data as LocalDataProvider).setData(sortedData);
   }
-
-  lineupIsSorter = false;
 });
 
 // If lineup order has changed, update matrix
-watch(lineupOrder, (newLineupOrder) => {
-  // If sort order has less length than number of nodes, we've filtered sort those nodes to the top
-  if (network.value !== null && newLineupOrder.length < network.value.nodes.length) {
-    return;
-  }
-
-  if (lineup.value !== null && network.value !== null && lineupIsSorter) {
-    const newSortOrder = newLineupOrder.map((i) => permutingMatrix[i]);
-    sortOrder.value = newSortOrder;
+watch(lineupOrder, () => {
+  if (lineup.value !== null && network.value !== null) {
+    lineup.value.data.getFirstRanking().setSortCriteria([]);
+    const sortedData = sortOrder.value.map((i) => (network.value !== null ? network.value.nodes[i] : {}));
+    (lineup.value.data as LocalDataProvider).setData(sortedData);
   }
 });
 
@@ -166,12 +159,6 @@ function buildLineup() {
       hoveredIDs.forEach((nodeID) => hoveredNodes.value.push(nodeID));
 
       [lastHovered] = hoveredIDs;
-    });
-
-    lineup.value.data.getFirstRanking().on('orderChanged', (oldOrder, newOrder, _, __, eventType) => {
-      if ((eventType as string[]).includes('sort_changed')) {
-        lineupIsSorter = true;
-      }
     });
 
     lineup.value.data.getFirstRanking().on('groupsChanged', (oldSortOrder: number[], newSortOrder: number[], oldGroups: { name: string }[], newGroups: { name: string }[]) => {

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -134,11 +134,12 @@ function hideToolTip() {
     .style('opacity', 0);
 }
 
-function showContextMenu(event: MouseEvent) {
+function showContextMenu(event: MouseEvent, nodeID?: string) {
   rightClickMenu.value = {
     show: true,
     top: event.y,
     left: event.x,
+    nodeID,
   };
 
   event.preventDefault();
@@ -347,6 +348,7 @@ function clickedNeighborClass(node: Node) {
                 @mouseover="(event) => { showToolTip(event, node); hoverNode(node._id); }"
                 @mouseout="(event) => { hideToolTip(); unHoverNode(node._id); }"
                 @click="clickElement(node)"
+                @contextmenu="e => { e.stopPropagation(); showContextMenu(e, node._id) }"
               />
               <foreignObject
                 :width="labelWidth"

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -241,6 +241,7 @@ processData();
 const highlightLength = computed(() => matrix.value.length * cellSize.value);
 const labelFontSize = computed(() => 0.8 * cellSize.value);
 const labelWidth = 60;
+const colLabelWidth = 100;
 const invisibleRectSize = 11;
 
 function clickElement(matrixElement: Node | Cell) {
@@ -343,13 +344,13 @@ const isSortedByNode = computed(() => sortBy.value !== null && network.value.nod
                 @contextmenu="e => { e.stopPropagation(); showContextMenu(e, node._id) }"
               />
               <foreignObject
-                :width="labelWidth"
+                :width="colLabelWidth"
                 :height="cellSize"
                 x="5"
               >
                 <p
                   :style="`margin-top: ${cellSize * -0.1}px; font-size: ${labelFontSize}px; color: ${(aggregated && node.type !== 'supernode') || (degreeFiltered && node.type !== 'supernode') ? '#AAAAAA' : '#000000'}`"
-                  class="label"
+                  class="label colLabel"
                 >
                   {{ node.type === 'supernode' || labelVariable === undefined ? node['_key'] : node[labelVariable] }}
                 </p>
@@ -469,6 +470,10 @@ const isSortedByNode = computed(() => sortBy.value !== null && network.value.nod
 </template>
 
 <style scoped>
+svg:deep(.colLabel) {
+  max-width: 100px !important;
+}
+
 svg:deep(.label) {
   max-width: 60px;
   text-overflow: ellipsis;

--- a/src/components/MultiMatrix.vue
+++ b/src/components/MultiMatrix.vue
@@ -349,10 +349,10 @@ function clickedNeighborClass(node: Node) {
                 x="5"
               >
                 <p
-                  :style="`margin-top: ${cellSize * -0.1}px; font-size: ${labelFontSize}px; color: ${(aggregated && node.type !== 'supernode') || (degreeFiltered && node.type !== 'supernode') ? '#AAAAAA' : '#000000'}`"
+                  :style="`margin-top: ${cellSize * -0.1}px; font-size: ${labelFontSize}px; color: ${(aggregated && node._type !== 'supernode') || (degreeFiltered && node._type !== 'supernode') ? '#AAAAAA' : '#000000'}`"
                   class="label colLabel"
                 >
-                  {{ node.type === 'supernode' || labelVariable === undefined ? node['_key'] : node[labelVariable] }}
+                  {{ node._type === 'supernode' || labelVariable === undefined ? node['_key'] : node[labelVariable] }}
                 </p>
               </foreignObject>
             </g>
@@ -381,10 +381,10 @@ function clickedNeighborClass(node: Node) {
                 :x="-labelWidth"
               >
                 <p
-                  :style="`margin-top: ${cellSize * -0.1}px; font-size: ${labelFontSize}px; color: ${aggregated && (node.type !== 'supernode') ? '#AAAAAA' : '#000000'}`"
+                  :style="`margin-top: ${cellSize * -0.1}px; font-size: ${labelFontSize}px; color: ${aggregated && (node._type !== 'supernode') ? '#AAAAAA' : '#000000'}`"
                   class="label"
                 >
-                  {{ node.type === 'supernode' || labelVariable === undefined ? node['_key'] : node[labelVariable] }}
+                  {{ node._type === 'supernode' || labelVariable === undefined ? node['_key'] : node[labelVariable] }}
                 </p>
               </foreignObject>
 

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -105,7 +105,12 @@ export function getTrrackLabel(updates: Partial<ProvState>, previousState: ProvS
   } else if (updates.slicingConfig !== undefined) {
     label = 'Slicing Configuration Updated';
   } else if (updates.sortBy !== undefined) {
-    label = updates.sortBy === null ? 'Sorting Removed' : `Sorted By: ${updates.sortBy}`;
+    // TODO
+    if (updates.sortBy.network !== previousState.sortBy.network) {
+      label = updates.sortBy.network === null ? 'Sorting Removed' : `Sorted By: ${updates.sortBy.network}`;
+    } else if (updates.sortBy.node !== previousState.sortBy.node) {
+      label = updates.sortBy.node === null ? 'Neighbor Sorting Removed' : 'Sorted By Neighbor';
+    }
   } else {
     label = 'Unknown Update';
   }

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -104,6 +104,8 @@ export function getTrrackLabel(updates: Partial<ProvState>, previousState: ProvS
     label = `Slice Index Set: ${updates.sliceIndex}`;
   } else if (updates.slicingConfig !== undefined) {
     label = 'Slicing Configuration Updated';
+  } else if (updates.sortBy !== undefined) {
+    label = updates.sortBy === null ? 'Sorting Removed' : `Sorted By: ${updates.sortBy}`;
   } else {
     label = 'Unknown Update';
   }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -451,18 +451,16 @@ export const useStore = defineStore('store', () => {
     const isNode = network.value.nodes.map((node: Node) => node._id).includes(nonNullSortBy);
 
     if (nonNullSortBy === 'Clusters') {
-      const newEdges: unknown[] = Array(network.value.edges.length);
+      const newEdges: unknown[] = [];
 
       // Generate edges that are compatible with reorder.js
-      network.value.edges.forEach((edge: Edge, index: number) => {
-        newEdges[index] = {
-          source: network.value.nodes.find(
-            (node: Node) => node._id === edge._from,
-          ),
-          target: network.value.nodes.find(
-            (node: Node) => node._id === edge._to,
-          ),
-        };
+      network.value.edges.forEach((edge: Edge) => {
+        const source = network.value.nodes.find((node: Node) => node._id === edge._from);
+        const target = network.value.nodes.find((node: Node) => node._id === edge._to);
+
+        if (source !== undefined && target !== undefined) {
+          newEdges.push({ source, target });
+        }
       });
 
       const sortableNetwork = reorder

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -461,11 +461,11 @@ export const useStore = defineStore('store', () => {
 
     if (nonNullSortBy === 'Alphabetically') {
       order.sort((a, b) => {
-        const aVal = `${network.value.nodes[a][labelVariable.value === undefined ? '_key' : labelVariable.value]}`;
-        const bVal = `${network.value.nodes[b][labelVariable.value === undefined ? '_key' : labelVariable.value]}`;
+        const aVal = network.value.nodes[a]._type === 'supernode' ? `${network.value.nodes[a][aggregatedBy.value === null ? '_key' : aggregatedBy.value]}` : `${network.value.nodes[a][labelVariable.value === undefined ? '_key' : labelVariable.value]}`;
+        const bVal = network.value.nodes[b]._type === 'supernode' ? `${network.value.nodes[b][aggregatedBy.value === null ? '_key' : aggregatedBy.value]}` : `${network.value.nodes[b][labelVariable.value === undefined ? '_key' : labelVariable.value]}`;
 
-        if (!Number.isNaN(parseInt(aVal, 10)) && !Number.isNaN(parseInt(aVal, 10))) {
-          return a < b ? -1 : 1;
+        if (!Number.isNaN(parseFloat(aVal)) && !Number.isNaN(parseFloat(aVal))) {
+          return parseFloat(aVal) - parseFloat(bVal);
         }
 
         return aVal.localeCompare(bVal);

--- a/src/store/provenance.ts
+++ b/src/store/provenance.ts
@@ -25,6 +25,7 @@ export const useProvenanceStore = defineStore('provenance', () => {
     isValidRange: false,
   });
   const sliceIndex = ref(0);
+  const sortBy = ref<string | null>(null);
 
   // A live computed state so that we can edit the values when trrack does undo/redo
   const currentPiniaState = computed(() => ({
@@ -39,6 +40,7 @@ export const useProvenanceStore = defineStore('provenance', () => {
     degreeRange,
     slicingConfig,
     sliceIndex,
+    sortBy,
   }));
 
   // Static snapshot of the initial state for trrack
@@ -123,5 +125,6 @@ export const useProvenanceStore = defineStore('provenance', () => {
     degreeRange,
     slicingConfig,
     sliceIndex,
+    sortBy,
   };
 });

--- a/src/store/provenance.ts
+++ b/src/store/provenance.ts
@@ -25,7 +25,7 @@ export const useProvenanceStore = defineStore('provenance', () => {
     isValidRange: false,
   });
   const sliceIndex = ref(0);
-  const sortBy = ref<string | null>(null);
+  const sortBy = ref<{ network : string | null; node: string | null }>({ network: null, node: null });
 
   // A live computed state so that we can edit the values when trrack does undo/redo
   const currentPiniaState = computed(() => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,7 @@ export interface ProvState {
   degreeRange: [number, number];
   sliceIndex: number;
   slicingConfig: SlicingConfig;
-  sortBy: string | null;
+  sortBy: { network: string | null; node: string | null };
 }
 
 export type ProvenanceEventTypes =

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,8 +26,6 @@ export interface Network {
 }
 
 export interface Cell {
-  x: number;
-  y: number;
   z: number;
   rowCellType?: string;
   colCellType?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,7 @@ export interface ProvState {
   degreeRange: [number, number];
   sliceIndex: number;
   slicingConfig: SlicingConfig;
+  sortBy: string | null;
 }
 
 export type ProvenanceEventTypes =


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #440
Closes #444 
Closes #445 

### Give a longer description of what this PR addresses and why it's needed
This fixes the matrix sorting and adds the sorting variable to the provenance store.

### Provide pictures/videos of the behavior before and after these changes (optional)
Nested sorting (alphabetical):
![image](https://user-images.githubusercontent.com/36867477/229238802-0207e938-28cd-4254-93b7-dd05282b3fe9.png)

Network Sorting (clusters):
![image](https://user-images.githubusercontent.com/36867477/229239096-6398c927-f83b-4d90-bae2-44ac0c7ea3c2.png)

Neighbor Sorting after alphabetical sorting:
![image](https://user-images.githubusercontent.com/36867477/229241836-d6020b06-58a9-48eb-a8fd-a36e18f2ae81.png)


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Fix issue with aggregated networks
- [x] Test with slicing
- [x] Check on eurovis network
- [x] UI: Make column labels longer
- [x] Disable lineup sorting
- [x] Bug with sorting and then neighbor sort
- [x] Interactions sort does nothing (replace with something better or fix)
- [x] Bug with aggregated sorting, adds too many indices
- [x] Aggregated labels aren't sorted properly
- [x] Row sorting is wrong for neighbors (currently resets order, instead of keeping col order and sorting neighbors to the top)