### PR TITLE
Allow setting cell size smaller and fix lineup infinite re-render bug and sort logic

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
     'no-debugger': ['error'],
     'vue/max-len': ['off'],
     'import/prefer-default-export': ['off'],
-    'no-underscore-dangle': ['error', { allow: ['_id', '_from', '_to', '_key', '_type'] }],
+    'no-underscore-dangle': ['error', { allow: ['_id', '_from', '_to', '_key', '_type', '_index'] }],
     ...a11yOff,
     'no-param-reassign': ['error', { props: false }],
     'import/extensions': ['error', { ts: 'never', vue: 'always' }],

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -27,7 +27,7 @@ const { rightClickMenu, sortBy } = storeToRefs(store);
         <v-list-item
           v-if="rightClickMenu.nodeID !== undefined"
           dense
-          @click="sortBy = { ...sortBy, node: node === rightClickMenu.nodeID ? null : rightClickMenu.nodeID, lineup: null }"
+          @click="sortBy = { ...sortBy, node: sortBy.node === rightClickMenu.nodeID ? null : rightClickMenu.nodeID }"
         >
           <v-list-item-content>
             <v-list-item-title>{{ sortBy.node === rightClickMenu.nodeID ? 'Remove Neighbor Sort' : 'Sort Neighbors' }}</v-list-item-title>

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -27,7 +27,7 @@ const { rightClickMenu, sortBy } = storeToRefs(store);
         <v-list-item
           v-if="rightClickMenu.nodeID !== undefined"
           dense
-          @click="sortBy.node = sortBy.node === rightClickMenu.nodeID ? null : rightClickMenu.nodeID"
+          @click="sortBy = { ...sortBy, node: node === rightClickMenu.nodeID ? null : rightClickMenu.nodeID, lineup: null }"
         >
           <v-list-item-content>
             <v-list-item-title>{{ sortBy.node === rightClickMenu.nodeID ? 'Remove Neighbor Sort' : 'Sort Neighbors' }}</v-list-item-title>

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -140,7 +140,7 @@ watch(expandedPanels, () => {
                 clearable
                 outlined
                 dense
-                @change="sortBy.node = null"
+                @change="sortBy = { ...sortBy, node: (sortBy.network === null ? sortBy.node : null), lineup: null }"
               />
             </v-list-item>
 

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -184,7 +184,7 @@ watch(expandedPanels, () => {
               Cell Size
               <v-slider
                 v-model="cellSize"
-                :min="10"
+                :min="5"
                 :max="100"
                 :label="String(cellSize)"
                 class="px-2 align-center"

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -29,12 +29,7 @@ if (matrixElement !== null) {
   matrixResizeObserver.observe(matrixElement);
 }
 
-const lineupOrder = computed(() => {
-  if (lineup.value === null || [...lineup.value.data.getFirstRanking().getOrder()].length === 0) {
-    return [...Array(network.value?.nodes.length).keys()];
-  }
-  return [...lineup.value.data.getFirstRanking().getOrder()];
-});
+const lineupOrder = ref<number[]>([]);
 
 // If store order has changed, update lineup
 let permutingMatrix = structuredClone(sortOrder.value.row);
@@ -136,6 +131,8 @@ function buildLineup() {
 
       [lastHovered] = hoveredIDs;
     });
+
+    lineup.value?.data.on('orderChanged', (order) => { lineupOrder.value = order; });
 
     lineup.value.data.getFirstRanking().on('groupsChanged', (oldSortOrder: number[], newSortOrder: number[], oldGroups: { name: string }[], newGroups: { name: string }[]) => {
       if (JSON.stringify(oldGroups.map((group) => group.name)) !== JSON.stringify(newGroups.map((group) => group.name))) {

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -8,6 +8,7 @@ import LineUp, {
 } from 'lineupjs';
 import { isInternalField } from '@/lib/typeUtils';
 import { storeToRefs } from 'pinia';
+import { arraysAreEqual } from '@/lib/provenanceUtils';
 
 const store = useStore();
 const {
@@ -43,11 +44,14 @@ watch(sortOrder, (newSortOrder) => {
 });
 
 // If lineup order has changed, update matrix
-watch(lineupOrder, () => {
+watch(lineupOrder, (newOrder, oldOrder) => {
   if (lineup.value !== null && network.value !== null) {
     lineup.value.data.getFirstRanking().setSortCriteria([]);
     const sortedData = sortOrder.value.row.map((i) => (network.value !== null ? network.value.nodes[i] : {}));
-    (lineup.value.data as LocalDataProvider).setData(sortedData);
+
+    if (!arraysAreEqual(newOrder, oldOrder)) {
+      (lineup.value.data as LocalDataProvider).setData(sortedData);
+    }
   }
 });
 

--- a/src/components/LineUp.vue
+++ b/src/components/LineUp.vue
@@ -172,6 +172,8 @@ watch(cellSize, () => {
 function removeHighlight() {
   hoveredNodes.value = [];
 }
+
+const labelFontSize = computed(() => `${0.8 * cellSize.value}px`);
 </script>
 
 <template>
@@ -197,5 +199,9 @@ function removeHighlight() {
 
 .le-body {
   overflow: hidden !important;
+}
+
+.le-td {
+  font-size: v-bind(labelFontSize);
 }
 </style>

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -25,7 +25,7 @@ export function isArray(input: unknown): input is Array<string> {
   return typeof input === 'object' && input !== null && input.constructor === Array;
 }
 
-function arraysAreEqual<T>(a: T[], b: T[]) {
+export function arraysAreEqual<T>(a: T[], b: T[]) {
   return a.length === b.length && a.every((element, index) => element === b[index]);
 }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -222,7 +222,7 @@ export const useStore = defineStore('store', () => {
     }
 
     // Reset sort order now that network has changed
-    sortBy.value = { network: null, node: null };
+    sortBy.value = { network: null, node: null, lineup: null };
 
     // Recalculate neighbors
     defineNeighbors(networkAfterOperations.nodes, networkAfterOperations.edges);
@@ -533,8 +533,8 @@ export const useStore = defineStore('store', () => {
     const rowOrder = sortBy.value.node === null ? colOrder : computeSortOrder(sortBy.value.node, colOrder);
 
     return {
-      row: rowOrder,
-      column: colOrder,
+      row: sortBy.value.lineup || rowOrder,
+      column: sortBy.value.lineup || colOrder,
     };
   });
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -147,7 +147,6 @@ export const useStore = defineStore('store', () => {
           children: value.map((node) => structuredClone(node)),
           _type: 'supernode',
           neighbors: [] as string[],
-          degreeCount: 0,
           [aggregatedBy.value!]: key,
         }),
       );
@@ -197,7 +196,6 @@ export const useStore = defineStore('store', () => {
       const filteredNode: Node = {
         _type: 'supernode',
         neighbors: [],
-        degreeCount: 0,
         _key: 'filtered',
         _id: 'filtered',
         _rev: '',
@@ -529,12 +527,13 @@ export const useStore = defineStore('store', () => {
     return order;
   }
   const sortOrder = computed(() => {
-    const colOrder = sortBy.value.network === null ? range(network.value.nodes.length) : computeSortOrder(sortBy.value.network);
+    const colOrder = sortBy.value.lineup
+      || (sortBy.value.network === null ? range(network.value.nodes.length) : computeSortOrder(sortBy.value.network));
     const rowOrder = sortBy.value.node === null ? colOrder : computeSortOrder(sortBy.value.node, colOrder);
 
     return {
-      row: sortBy.value.lineup || rowOrder,
-      column: sortBy.value.lineup || colOrder,
+      row: rowOrder,
+      column: colOrder,
     };
   });
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -277,7 +277,8 @@ export const useStore = defineStore('store', () => {
 
     // If there are label candidates, set the label variable to the first one
     if (labelCandidate.length > 0) {
-      [labelVariable.value] = labelCandidate;
+      // eslint-disable-next-line prefer-destructuring
+      labelVariable.value = labelCandidate[0];
     }
   });
 

--- a/src/store/provenance.ts
+++ b/src/store/provenance.ts
@@ -27,7 +27,7 @@ export const useProvenanceStore = defineStore('provenance', () => {
     isValidRange: false,
   });
   const sliceIndex = ref(0);
-  const sortBy = ref<{ network : string | null; node: string | null }>({ network: null, node: null });
+  const sortBy = ref<{ network : string | null; node: string | null; lineup: number[] | null }>({ network: null, node: null, lineup: null });
 
   // A live computed state so that we can edit the values when trrack does undo/redo
   const currentPiniaState = computed(() => ({

--- a/src/store/provenance.ts
+++ b/src/store/provenance.ts
@@ -14,7 +14,7 @@ export const useProvenanceStore = defineStore('provenance', () => {
   const selectedNodes = ref<string[]>([]);
   const selectedCell = ref<Cell | null>(null);
   const aggregatedBy = ref<string | null>(null);
-  const labelVariable = ref<string | undefined>(undefined);
+  const labelVariable = ref<string | null>(null);
   const expandedNodeIDs = ref<string[]>([]);
   const degreeRange = ref<[number, number]>([0, 0]);
   const slicingConfig = ref<SlicingConfig>({

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@ export interface Dimensions {
 
 export interface Node extends TableRow {
   neighbors: string[];
-  degreeCount: number;
   children?: Node[];
   parentPosition?: number;
   _type?: string;


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #443
Closes #462

### Give a longer description of what this PR addresses and why it's needed
This PR fixes a few bugs with lineup and adds the ability to make the matrix cells smaller.

For the matrix cells, I just had to increase the size of the range that I could use for the cells. There was also a bug where the lineup font size was not updating with the cell size correctly that I addressed.

In lineup, I changed the sort logic to allow lineup to sort the matrix and I'm currently working on opposite direction. There were also some bugs that led to the matrix re-rendering constantly that are addressed as a part of this fix. Somehow, the sort order was being changed which would trigger lineup to update the data and then re-render. Quite a mess.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] #462 (Waiting on guidance from Austria for sorting)